### PR TITLE
Upgrade to `ring` 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changes
 
+## Unreleased
+
+- Remove `TryFrom<[u8]>` and `TryFrom<Vec<u8>>` for `KeyPair` in favor of allowing `KeyPair::from_der` to take `impl Into<Cow<'b, [u8]>>` which allows `Vec<u8>` as well as `[u8]`.
+
 ## Release 0.10.0 - September 29, 2022
 
 - Update x509-parser to 0.14.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 ## Unreleased
 
 - Remove `TryFrom<[u8]>` and `TryFrom<Vec<u8>>` for `KeyPair` in favor of allowing `KeyPair::from_der` to take `impl Into<Cow<'b, [u8]>>` which allows `Vec<u8>` as well as `[u8]`.
+- Add `ring::rand::SecureRandom` parameter to:
+  - `KeyPair::generate`
+  - `KeyPair::from_der`
+  - `KeyPair::from_der_and_sign_algo`
+  - `KeyPair::from_pem`
+  - `KeyPair::from_pem_and_sign_algo`
 
 ## Release 0.10.0 - September 29, 2022
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -530,7 +530,7 @@ dependencies = [
  "openssl",
  "pem",
  "rand",
- "ring",
+ "ring 0.17.0-not-released-yet",
  "rsa",
  "time",
  "webpki",
@@ -548,9 +548,22 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.0-not-released-yet"
+source = "git+https://github.com/briansmith/ring#00fc3f35f3ed9e91fdb6b1e97226dc45cfe2c8f5"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.9.4",
+ "untrusted 0.9.0",
  "winapi",
 ]
 
@@ -594,6 +607,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 
 [[package]]
 name = "spki"
@@ -691,6 +710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,8 +803,8 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -817,7 +842,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
- "ring",
+ "ring 0.16.20",
  "rusticata-macros",
  "thiserror",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["pem"]
 
 [dependencies]
 yasna = { version = "0.5", features = ["time", "std"] }
-ring = "0.16"
+ring = { git = "https://github.com/briansmith/ring" }
 pem = { version = "1.0", optional = true }
 time = { version = "0.3.6", default-features = false }
 x509-parser = { version = "0.14", features = ["verify"], optional = true }

--- a/examples/rsa-irc-openssl.rs
+++ b/examples/rsa-irc-openssl.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let pkey :openssl::pkey::PKey<_> = openssl::rsa::Rsa::generate(2048)?.try_into()?;
 	let key_pair_pem = String::from_utf8(pkey.private_key_to_pem_pkcs8()?)?;
-	let key_pair = rcgen::KeyPair::from_pem(&key_pair_pem)?;
+	let key_pair = rcgen::KeyPair::from_pem(&key_pair_pem, &ring::rand::SystemRandom::new())?;
 	params.key_pair = Some(key_pair);
 
 	let cert = Certificate::from_params(params)?;

--- a/examples/rsa-irc.rs
+++ b/examples/rsa-irc.rs
@@ -7,7 +7,6 @@ use rand::rngs::OsRng;
 use rcgen::{Certificate, CertificateParams,
 	DistinguishedName, date_time_ymd};
 use std::fs;
-use std::convert::TryFrom;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let mut params :CertificateParams = Default::default();
@@ -21,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bits = 2048;
 	let private_key = RsaPrivateKey::new(&mut rng, bits)?;
 	let private_key_der = private_key.to_pkcs8_der()?;
-	let key_pair = rcgen::KeyPair::try_from(private_key_der.as_ref()).unwrap();
+	let key_pair = rcgen::KeyPair::from_der(private_key_der.as_ref()).unwrap();
 	params.key_pair = Some(key_pair);
 
 	let cert = Certificate::from_params(params)?;

--- a/examples/rsa-irc.rs
+++ b/examples/rsa-irc.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bits = 2048;
 	let private_key = RsaPrivateKey::new(&mut rng, bits)?;
 	let private_key_der = private_key.to_pkcs8_der()?;
-	let key_pair = rcgen::KeyPair::from_der(private_key_der.as_ref()).unwrap();
+	let key_pair = rcgen::KeyPair::from_der(private_key_der.as_ref(), &ring::rand::SystemRandom::new()).unwrap();
 	params.key_pair = Some(key_pair);
 
 	let cert = Certificate::from_params(params)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1660,13 +1660,35 @@ impl fmt::Display for RcgenError {
 			Time => write!(f, "Time error")?,
 			RemoteKeyError => write!(f, "Remote key error")?,
 			#[cfg(feature = "pem")]
-			PemError(e) => write!(f, "PEM error: {}", e)?,
+			PemError(_) => write!(f, "PEM error")?,
 		};
 		Ok(())
 	}
 }
 
-impl Error for RcgenError {}
+impl Error for RcgenError {
+	fn source(&self) -> Option<&(dyn Error + 'static)> {
+		match self {
+			#[cfg(feature = "pem")]
+			RcgenError::PemError(inner) => Some(inner),
+			RcgenError::RingKeyRejected(_) => None,
+			RcgenError::CouldNotParseCertificate => None,
+			RcgenError::CouldNotParseCertificationRequest => None,
+			RcgenError::CouldNotParseKeyPair => None,
+			#[cfg(feature = "x509-parser")]
+			RcgenError::InvalidNameType => None,
+			RcgenError::InvalidIpAddressOctetLength(_) => None,
+			RcgenError::KeyGenerationUnavailable => None,
+			#[cfg(feature = "x509-parser")]
+			RcgenError::UnsupportedExtension => None,
+			RcgenError::UnsupportedSignatureAlgorithm => None,
+			RcgenError::RingUnspecified => None,
+			RcgenError::CertificateKeyPairMismatch => None,
+			RcgenError::Time => None,
+			RcgenError::RemoteKeyError => None,
+		}
+	}
+}
 
 impl From<ring::error::Unspecified> for RcgenError {
 	fn from(_unspecified :ring::error::Unspecified) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1620,7 +1620,7 @@ pub enum RcgenError {
 	/// Unspecified `ring` error
 	RingUnspecified,
 	/// The `ring` library rejected the key upon loading
-	RingKeyRejected(&'static str),
+	RingKeyRejected(String), // TODO: Change this to `ring::error::KeyRejected` once it implements `PartialEq`.
 	/// The provided certificate's signature algorithm
 	/// is incompatible with the given key pair
 	CertificateKeyPairMismatch,
@@ -1653,7 +1653,7 @@ impl fmt::Display for RcgenError {
 			#[cfg(feature = "x509-parser")]
 			UnsupportedExtension => write!(f, "Unsupported extension requested in CSR")?,
 			RingUnspecified => write!(f, "Unspecified ring error")?,
-			RingKeyRejected(e) => write!(f, "Key rejected by ring: {}", e)?,
+			RingKeyRejected(reason) => write!(f, "Key rejected by ring: {}", reason)?,
 			CertificateKeyPairMismatch => write!(f, "The provided certificate's signature \
 				algorithm is incompatible with the given key pair")?,
 
@@ -1698,7 +1698,7 @@ impl From<ring::error::Unspecified> for RcgenError {
 
 impl From<ring::error::KeyRejected> for RcgenError {
 	fn from(err :ring::error::KeyRejected) -> Self {
-		RcgenError::RingKeyRejected(err.description_())
+		RcgenError::RingKeyRejected(err.to_string())
 	}
 }
 

--- a/tests/botan.rs
+++ b/tests/botan.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "x509-parser")]
 use rcgen::DnValue;
-use rcgen::{BasicConstraints, Certificate, CertificateParams, DnType, IsCa};
+use rcgen::{BasicConstraints, Certificate, CertificateParams, DnType, IsCa, KeyPair};
 
 mod util;
 
@@ -151,14 +151,13 @@ fn test_botan_separate_ca() {
 #[cfg(feature = "x509-parser")]
 #[test]
 fn test_botan_imported_ca() {
-	use std::convert::TryInto;
 	let mut params = default_params();
 	params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
 	let ca_cert = Certificate::from_params(params).unwrap();
 
 	let (ca_cert_der, ca_key_der) = (ca_cert.serialize_der().unwrap(), ca_cert.serialize_private_key_der());
 
-	let ca_key_pair = ca_key_der.as_slice().try_into().unwrap();
+	let ca_key_pair = KeyPair::from_der(ca_key_der).unwrap();
 	let imported_ca_cert_params = CertificateParams::from_ca_cert_der(ca_cert_der.as_slice(), ca_key_pair)
 		.unwrap();
 	let imported_ca_cert = Certificate::from_params(imported_ca_cert_params).unwrap();
@@ -177,7 +176,6 @@ fn test_botan_imported_ca() {
 #[cfg(feature = "x509-parser")]
 #[test]
 fn test_botan_imported_ca_with_printable_string() {
-	use std::convert::TryInto;
 	let mut params = default_params();
 	params.distinguished_name.push(DnType::CountryName, DnValue::PrintableString("US".to_string()));
 	params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
@@ -185,7 +183,7 @@ fn test_botan_imported_ca_with_printable_string() {
 
 	let (ca_cert_der, ca_key_der) = (ca_cert.serialize_der().unwrap(), ca_cert.serialize_private_key_der());
 
-	let ca_key_pair = ca_key_der.as_slice().try_into().unwrap();
+	let ca_key_pair = KeyPair::from_der(ca_key_der).unwrap();
 	let imported_ca_cert_params = CertificateParams::from_ca_cert_der(ca_cert_der.as_slice(), ca_key_pair)
 		.unwrap();
 	let imported_ca_cert = Certificate::from_params(imported_ca_cert_params).unwrap();

--- a/tests/botan.rs
+++ b/tests/botan.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "x509-parser")]
-use rcgen::DnValue;
-use rcgen::{BasicConstraints, Certificate, CertificateParams, DnType, IsCa, KeyPair};
+use ring::rand::SystemRandom;
+#[cfg(feature = "x509-parser")]
+use rcgen::{DnValue, KeyPair};
+use rcgen::{BasicConstraints, Certificate, CertificateParams, DnType, IsCa};
 
 mod util;
 
@@ -85,7 +87,7 @@ fn test_botan_25519_v1_given() {
 	let mut params = default_params();
 	params.alg = &rcgen::PKCS_ED25519;
 
-	let kp = rcgen::KeyPair::from_pem(util::ED25519_TEST_KEY_PAIR_PEM_V1).unwrap();
+	let kp = rcgen::KeyPair::from_pem(util::ED25519_TEST_KEY_PAIR_PEM_V1, &ring::rand::SystemRandom::new()).unwrap();
 	params.key_pair = Some(kp);
 
 	let cert = Certificate::from_params(params).unwrap();
@@ -101,7 +103,7 @@ fn test_botan_25519_v2_given() {
 	let mut params = default_params();
 	params.alg = &rcgen::PKCS_ED25519;
 
-	let kp = rcgen::KeyPair::from_pem(util::ED25519_TEST_KEY_PAIR_PEM_V2).unwrap();
+	let kp = rcgen::KeyPair::from_pem(util::ED25519_TEST_KEY_PAIR_PEM_V2, &ring::rand::SystemRandom::new()).unwrap();
 	params.key_pair = Some(kp);
 
 	let cert = Certificate::from_params(params).unwrap();
@@ -117,7 +119,7 @@ fn test_botan_rsa_given() {
 	let mut params = default_params();
 	params.alg = &rcgen::PKCS_RSA_SHA256;
 
-	let kp = rcgen::KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM).unwrap();
+	let kp = rcgen::KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM, &ring::rand::SystemRandom::new()).unwrap();
 	params.key_pair = Some(kp);
 
 	let cert = Certificate::from_params(params).unwrap();
@@ -157,7 +159,7 @@ fn test_botan_imported_ca() {
 
 	let (ca_cert_der, ca_key_der) = (ca_cert.serialize_der().unwrap(), ca_cert.serialize_private_key_der());
 
-	let ca_key_pair = KeyPair::from_der(ca_key_der).unwrap();
+	let ca_key_pair = KeyPair::from_der(ca_key_der, &SystemRandom::new()).unwrap();
 	let imported_ca_cert_params = CertificateParams::from_ca_cert_der(ca_cert_der.as_slice(), ca_key_pair)
 		.unwrap();
 	let imported_ca_cert = Certificate::from_params(imported_ca_cert_params).unwrap();
@@ -183,7 +185,7 @@ fn test_botan_imported_ca_with_printable_string() {
 
 	let (ca_cert_der, ca_key_der) = (ca_cert.serialize_der().unwrap(), ca_cert.serialize_private_key_der());
 
-	let ca_key_pair = KeyPair::from_der(ca_key_der).unwrap();
+	let ca_key_pair = KeyPair::from_der(ca_key_der, &SystemRandom::new()).unwrap();
 	let imported_ca_cert_params = CertificateParams::from_ca_cert_der(ca_cert_der.as_slice(), ca_key_pair)
 		.unwrap();
 	let imported_ca_cert = Certificate::from_params(imported_ca_cert_params).unwrap();

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -33,7 +33,7 @@ fn test_key_params_mismatch() {
 			if i != 0 {
 				wrong_params.key_pair = Some(KeyPair::generate(kalg_1).unwrap());
 			} else {
-				let kp = KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM).unwrap();
+				let kp = KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM, &ring::rand::SystemRandom::new()).unwrap();
 				wrong_params.key_pair = Some(kp);
 			}
 			wrong_params.alg = *kalg_2;

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -31,7 +31,7 @@ fn test_key_params_mismatch() {
 
 			let mut wrong_params = util::default_params();
 			if i != 0 {
-				wrong_params.key_pair = Some(KeyPair::generate(kalg_1).unwrap());
+				wrong_params.key_pair = Some(KeyPair::generate(kalg_1, &ring::rand::SystemRandom::new()).unwrap());
 			} else {
 				let kp = KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM, &ring::rand::SystemRandom::new()).unwrap();
 				wrong_params.key_pair = Some(kp);

--- a/tests/openssl.rs
+++ b/tests/openssl.rs
@@ -227,7 +227,7 @@ fn test_openssl_25519_v1_given() {
 	let mut params = util::default_params();
 	params.alg = &rcgen::PKCS_ED25519;
 
-	let kp = rcgen::KeyPair::from_pem(util::ED25519_TEST_KEY_PAIR_PEM_V1).unwrap();
+	let kp = rcgen::KeyPair::from_pem(util::ED25519_TEST_KEY_PAIR_PEM_V1, &ring::rand::SystemRandom::new()).unwrap();
 	params.key_pair = Some(kp);
 
 	let cert = Certificate::from_params(params).unwrap();
@@ -248,7 +248,7 @@ fn test_openssl_25519_v2_given() {
 	let mut params = util::default_params();
 	params.alg = &rcgen::PKCS_ED25519;
 
-	let kp = rcgen::KeyPair::from_pem(util::ED25519_TEST_KEY_PAIR_PEM_V2).unwrap();
+	let kp = rcgen::KeyPair::from_pem(util::ED25519_TEST_KEY_PAIR_PEM_V2, &ring::rand::SystemRandom::new()).unwrap();
 	params.key_pair = Some(kp);
 
 	let cert = Certificate::from_params(params).unwrap();
@@ -266,7 +266,7 @@ fn test_openssl_rsa_given() {
 	let mut params = util::default_params();
 	params.alg = &rcgen::PKCS_RSA_SHA256;
 
-	let kp = rcgen::KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM).unwrap();
+	let kp = rcgen::KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM, &ring::rand::SystemRandom::new()).unwrap();
 	params.key_pair = Some(kp);
 
 	let cert = Certificate::from_params(params).unwrap();
@@ -288,7 +288,7 @@ fn test_openssl_rsa_combinations_given() {
 		let mut params = util::default_params();
 		params.alg = alg;
 
-		let kp = rcgen::KeyPair::from_pem_and_sign_algo(util::RSA_TEST_KEY_PAIR_PEM, alg).unwrap();
+		let kp = rcgen::KeyPair::from_pem_and_sign_algo(util::RSA_TEST_KEY_PAIR_PEM, alg, &ring::rand::SystemRandom::new()).unwrap();
 		params.key_pair = Some(kp);
 
 		let cert = Certificate::from_params(params).unwrap();

--- a/tests/webpki.rs
+++ b/tests/webpki.rs
@@ -271,7 +271,7 @@ fn from_remote() {
 		}
 	}
 
-	let key_pair = KeyPair::generate(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let key_pair = KeyPair::generate(&rcgen::PKCS_ECDSA_P256_SHA256, &SystemRandom::new()).unwrap();
 	let remote = EcdsaKeyPair::from_pkcs8(&signature::ECDSA_P256_SHA256_ASN1_SIGNING, &key_pair.serialize_der(), &SystemRandom::new()).unwrap();
 	let key_pair = EcdsaKeyPair::from_pkcs8(&signature::ECDSA_P256_SHA256_ASN1_SIGNING, &key_pair.serialize_der(), &SystemRandom::new()).unwrap();
 	let remote = KeyPair::from_remote(Box::new(Remote(remote))).unwrap();

--- a/tests/webpki.rs
+++ b/tests/webpki.rs
@@ -333,14 +333,13 @@ fn test_webpki_separate_ca_name_constraints() {
 #[cfg(feature = "x509-parser")]
 #[test]
 fn test_webpki_imported_ca() {
-	use std::convert::TryInto;
 	let mut params = util::default_params();
 	params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
 	let ca_cert = Certificate::from_params(params).unwrap();
 
 	let (ca_cert_der, ca_key_der) = (ca_cert.serialize_der().unwrap(), ca_cert.serialize_private_key_der());
 
-	let ca_key_pair = ca_key_der.as_slice().try_into().unwrap();
+	let ca_key_pair = KeyPair::from_der(ca_key_der).unwrap();
 	let imported_ca_cert_params = CertificateParams::from_ca_cert_der(ca_cert_der.as_slice(), ca_key_pair)
 		.unwrap();
 	let imported_ca_cert = Certificate::from_params(imported_ca_cert_params).unwrap();
@@ -360,7 +359,6 @@ fn test_webpki_imported_ca() {
 #[cfg(feature = "x509-parser")]
 #[test]
 fn test_webpki_imported_ca_with_printable_string() {
-	use std::convert::TryInto;
 	let mut params = util::default_params();
 	params.distinguished_name.push(DnType::CountryName, DnValue::PrintableString("US".to_string()));
 	params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
@@ -368,7 +366,7 @@ fn test_webpki_imported_ca_with_printable_string() {
 
 	let (ca_cert_der, ca_key_der) = (ca_cert.serialize_der().unwrap(), ca_cert.serialize_private_key_der());
 
-	let ca_key_pair = ca_key_der.as_slice().try_into().unwrap();
+	let ca_key_pair = KeyPair::from_der(ca_key_der).unwrap();
 	let imported_ca_cert_params = CertificateParams::from_ca_cert_der(ca_cert_der.as_slice(), ca_key_pair)
 		.unwrap();
 	let imported_ca_cert = Certificate::from_params(imported_ca_cert_params).unwrap();


### PR DESCRIPTION
This PR prepares the library for the next ring release. Most prominently, `ring` now exposes its randomness source properly for `ECDSA` keypairs. In a bigger context, this now allows for deterministic certificates!

See https://github.com/melekes/rust-libp2p/pull/12.