### PR TITLE
Enable botan CI on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+    - uses: egor-tensin/vs-shell@v2
+      with:
+        arch: amd64
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    env:
+      # botan doesn't build on windows if the source is
+      # on a different drive than the artifacts
+      # https://github.com/randombit/botan-rs/issues/82
+      BOTAN_CONFIGURE_LINK_METHOD: copy
     steps:
     - uses: actions/checkout@v4
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,9 @@ features = ["x509-parser"]
 openssl = "0.10"
 x509-parser = { version = "0.15", features = ["verify"] }
 rustls-webpki = { version = "0.101.0", features = ["std"] }
+botan = { version = "0.10", features = ["vendored"] }
 rand = "0.8"
 rsa = "0.9"
-
-[target.'cfg(not(windows))'.dev-dependencies]
-botan = { version = "0.10", features = ["vendored"] }
-
 
 # This greatly speeds up rsa key generation times
 # (only applies to the dev-dependency because cargo

--- a/tests/botan.rs
+++ b/tests/botan.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "x509-parser", not(windows)))]
+#![cfg(feature = "x509-parser")]
 
 use rcgen::DnValue;
 use rcgen::{BasicConstraints, Certificate, CertificateParams, DnType, IsCa};


### PR DESCRIPTION
In #118, windows CI was added but the botan specific tests were disabled as the build for rust doesn't work.

I'm opening this PR for future discussion and work on botan support on the windows CI. The goal is to get the CI green, and until then it can't be merged.