### PR TITLE
Update pem to 3.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "2.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["pem"]
 [dependencies]
 yasna = { version = "0.5.2", features = ["time", "std"] }
 ring = "0.16"
-pem = { version = "2.0.1", optional = true }
+pem = { version = "3.0.2", optional = true }
 time = { version = "0.3.6", default-features = false }
 x509-parser = { version = "0.15", features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,12 @@ mod sign_algo;
 // Uses ECDSA: https://crt.sh/?asn1=607203242
 
 #[cfg(feature = "pem")]
-const ENCODE_CONFIG: pem::EncodeConfig = match cfg!(target_family = "windows") {
-	true => pem::EncodeConfig { line_ending: pem::LineEnding::CRLF },
-	false => pem::EncodeConfig { line_ending: pem::LineEnding::LF },
+const ENCODE_CONFIG: pem::EncodeConfig = {
+	let line_ending = match cfg!(target_family = "windows") {
+		true => pem::LineEnding::CRLF,
+		false => pem::LineEnding::LF,
+	};
+	pem::EncodeConfig::new().set_line_ending(line_ending)
 };
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]


### PR DESCRIPTION
Update to pem >= 3.0.2, which has this PR integrated: https://github.com/jcreekmore/pem-rs/pull/51