### PR TITLE
tests: fix webpki CRL test, deprecations.

### DIFF
--- a/tests/util.rs
+++ b/tests/util.rs
@@ -82,7 +82,7 @@ pub fn test_crl() -> (CertificateRevocationList, Certificate) {
 	let now = OffsetDateTime::now_utc();
 	let next_week = now + Duration::weeks(1);
 	let revoked_cert = RevokedCertParams{
-		serial_number: SerialNumber::from_slice(&[0xC0, 0xFF, 0xEE]),
+		serial_number: SerialNumber::from_slice(&[0x00, 0xC0, 0xFF, 0xEE]),
 		revocation_time: now,
 		reason_code: Some(RevocationReason::KeyCompromise),
 		invalidity_date: None,


### PR DESCRIPTION
### tests: fix webpki CRL test.
Previously the `test_crl` fn generated a certificate revocation list that had a revoked certificate entry with the serial number `0xC0FFEE` - this constant has a binary representation of `110000001111111111101110`, where the MSB is 1. This makes the serial number negative, in contradiction to RFC 5280's requirements for serial numbers.

The Yasna-based encoder that rcgen uses for emitting the serial number accounted for this by prepending 0x00 automatically. This should have resulted in a failure to find the literal serial `0xC0FFEE` in the webpki CRL, except that webpki was incorrectly canonicalizing the serial number for the CRL representation, meaning the `0x00C0FFEE` serial emitted by rcgen was stored as `0xC0FFEE`, matching our lookup and allowing the test to pass.

In Webpki v0.101.2 we removed the inappropriate canonicalization (https://github.com/rustls/webpki/commit/e9e4955daeedfdfcf7eb3d25a6256fbbe58b92a9), meaning the rcgen emitted serial of `0x00C0FFEE` was stored as-is, and a lookup for `0xC0FFEE` no longer found a revoked certificate, making the test fail.

This commit fixes the above by explicitly using `0x00C0FFEE` as the serial number used for encoding of the revoked certificate's serial, and the lookup operation.

Resolves https://github.com/rustls/rcgen/issues/141

### tests: fix webpki deprecations, remove allow.

The upstream webpki deprecated the per-usage trust anchor representation and end entity certificate verification functions. Instead, we now use the general `TrustAnchor` type and invoke `verify_for_usage` with the intended `KeyUsage`.
