### PR TITLE
ci: add dependabot config for GitHub actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This will let Dependabot keep the CI GitHub action versions up to date.

For the time being we choose not to configure Dependabot for the cargo ecosystem since its generally more noise/work to keep up with.