### PR TITLE
Unpin time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        override: true
     - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
     - run: vcpkg install openssl:x64-windows-static-md
     - name: Run cargo check --all
@@ -48,7 +47,6 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.toolchain }}
-        override: true
     - name: Run cargo check --all
       run: cargo check --all
     - name: Run the tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["pem"]
 yasna = { version = "0.5.2", features = ["time", "std"] }
 ring = "0.16"
 pem = { version = "3.0.2", optional = true }
-time = { version = ">=0.3.6, <=0.3.23", default-features = false }
+time = { version = "0.3.6", default-features = false }
 x509-parser = { version = "0.15", features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }
 


### PR DESCRIPTION
As suggested by @rukai in #144, I agree that libraries should almost never use precise dependency requirements. Given that we have a `Cargo.lock` file, we can use it to stick to the older time release to ensure we can work on older MSRV.