### PR TITLE
project: codecov comments only for changes.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  require_changes: true


### PR DESCRIPTION
This commit adds a `codecov.yml` configuration file that instructs Codecov.io to only add a comment to pull requests when coverage changes.

See the [codecov docs](https://docs.codecov.com/docs/pull-request-comments) for more information.

If this is still too noisy for our preferences we can adjust the config to `comment: false` in a follow-up.
