### PR TITLE
lib: use ext helper in more places, test custom exts.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -999,11 +999,7 @@ impl CertificateParams {
 
 						// Write standard key usage
 						if !self.key_usages.is_empty() {
-							writer.next().write_sequence(|writer| {
-								let oid = ObjectIdentifier::from_slice(OID_KEY_USAGE);
-								writer.next().write_oid(&oid);
-								writer.next().write_bool(true);
-
+							write_x509_extension(writer.next(), OID_KEY_USAGE, true, |writer| {
 								let mut bits: u16 = 0;
 
 								for entry in self.key_usages.iter() {
@@ -1032,12 +1028,7 @@ impl CertificateParams {
 								// Finally take only the bytes != 0
 								let bits = &bits[..nb];
 
-								let der = yasna::construct_der(|writer| {
-									writer.write_bitvec_bytes(&bits, msb as usize)
-								});
-
-								// Write them
-								writer.next().write_bytes(&der);
+								writer.write_bitvec_bytes(&bits, msb as usize)
 							});
 						}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -911,7 +911,7 @@ impl CertificateParams {
 			// Write extensions
 			// According to the spec in RFC 2986, even if attributes are empty we need the empty attribute tag
 			writer.next().write_tagged(Tag::context(0), |writer| {
-				if !subject_alt_names.is_empty() {
+				if !subject_alt_names.is_empty() || !custom_extensions.is_empty() {
 					writer.write_sequence(|writer| {
 						let oid = ObjectIdentifier::from_slice(OID_PKCS_9_AT_EXTENSION_REQUEST);
 						writer.next().write_oid(&oid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -922,17 +922,12 @@ impl CertificateParams {
 
 								// Write custom extensions
 								for ext in custom_extensions {
-									writer.next().write_sequence(|writer| {
-										let oid = ObjectIdentifier::from_slice(&ext.oid);
-										writer.next().write_oid(&oid);
-										// If the extension is critical, we should signal this.
-										// It's false by default so we don't need to write anything
-										// if the extension is not critical.
-										if ext.critical {
-											writer.next().write_bool(true);
-										}
-										writer.next().write_bytes(&ext.content);
-									});
+									write_x509_extension(
+										writer.next(),
+										&ext.oid,
+										ext.critical,
+										|writer| writer.write_der(ext.content()),
+									);
 								}
 							});
 						});
@@ -1148,16 +1143,8 @@ impl CertificateParams {
 
 						// Write the custom extensions
 						for ext in &self.custom_extensions {
-							writer.next().write_sequence(|writer| {
-								let oid = ObjectIdentifier::from_slice(&ext.oid);
-								writer.next().write_oid(&oid);
-								// If the extension is critical, we should signal this.
-								// It's false by default so we don't need to write anything
-								// if the extension is not critical.
-								if ext.critical {
-									writer.next().write_bool(true);
-								}
-								writer.next().write_bytes(&ext.content);
+							write_x509_extension(writer.next(), &ext.oid, ext.critical, |writer| {
+								writer.write_der(ext.content())
 							});
 						}
 					});

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -111,6 +111,9 @@ mod test_x509_custom_ext {
 		// Generate a certificate with the custom extension, parse it with x509-parser.
 		let mut params = util::default_params();
 		params.custom_extensions = vec![custom_ext];
+		// Ensure the custom exts. being omitted into a CSR doesn't require SAN ext being present.
+		// See https://github.com/rustls/rcgen/issues/122
+		params.subject_alt_names = Vec::default();
 		let test_cert = Certificate::from_params(params).unwrap();
 		let test_cert_der = test_cert.serialize_der().unwrap();
 		let (_, x509_test_cert) = X509Certificate::from_der(&test_cert_der).unwrap();


### PR DESCRIPTION
This branch updates a couple places that were writing x509 extensions by hand to use the existing `write_x509_extension` helper instead. 

Since custom extensions are a bit trickier a unit test for custom extensions in CSRs and certificates is added before refactoring the existing code to use the helper. This helps ensure the change is a no-op from the perspective of users.

With the updated test, it was possible to demonstrate a bug similar to https://github.com/rustls/rcgen/issues/122. The CSR serialization logic requiring SANs to be present in order to emit the custom extensions into the CSR PKCS9 extension request attribute. This branch fixes the issue.

