### PR TITLE
docs: update CHANGELOG for pending 0.11.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 
 # Changes
 
+## Release 0.11.2 - Pending Release
+
+- Project repository is now part of the [rustls](https://github.com/rustls) organization.
+- Support for retrieving signature algorithm from `KeyPair`s. Contributed by [tindzk](https://github.com/tindzk).
+- Fix for writing certificate signing requests (CSRs) with custom extensions from parameters without subject alternative names.
+- Support for certificate CRL distribution points extension.
+- Corrected OID for `ExtendedKeyUsagePurpose::Any`. Contributed by [jgallagher](https://github.com/jgallagher).
+- Support for creating certificate revocation lists (CRLs).
+
 ## Release 0.11.1 - June 17, 2023
 
 - Make botan a dev-dependency again. Contributed by [mbrubeck](https://github.com/mbrubeck).


### PR DESCRIPTION
To support https://github.com/rustls/rcgen/issues/156 this commit updates `CHANGELOG.md` with some notes for the upcoming 0.11.2 release.

I've omitted changes that are crate internal (refactorings, dependency updates, CI changes, comment fixes, etc) and focused on the changes I suspect are most meaningful to downstream consumers. As discussed in #156 I've also omitted explicit credit for features contributed by a maintainer (est31, djc or myself).
