### PR TITLE
Release 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 
 # Changes
 
-## Release 0.11.2 - Pending Release
+## Release 0.11.2 - September 21, 2023
 
-- Project repository is now part of the [rustls](https://github.com/rustls) organization.
+- `rcgen` has joined the umbrella of the [rustls](https://github.com/rustls) organization.
 - Support for retrieving signature algorithm from `KeyPair`s. Contributed by [tindzk](https://github.com/tindzk).
 - Fix for writing certificate signing requests (CSRs) with custom extensions from parameters without subject alternative names.
 - Support for certificate CRL distribution points extension.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "botan",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcgen"
-version = "0.11.1"
+version = "0.11.2"
 description = "Rust X.509 certificate generator"
 repository = "https://github.com/est31/rcgen"
 documentation = "https://docs.rs/rcgen"


### PR DESCRIPTION
Closes #156.

This is the first release of rcgen at its new home in the `rustls` github organization. I want to use this opportunity to thank @cpu , @djc and the other rustls members for their help with maintaining rcgen and letting rcgen join the `rustls` organization.