### PR TITLE
fix import errors for builds w/o optional pem feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --all-features
+      - run: cargo clippy --no-default-features
 
   rustdoc:
     name: Documentation
@@ -86,6 +87,8 @@ jobs:
       run: cargo test --all
     - name: Run the tests with x509-parser enabled
       run: cargo test --verbose --features x509-parser
+    - name: Run the tests with no default features enabled
+      run: cargo test --verbose --no-default-features
 
   build:
     strategy:
@@ -114,6 +117,8 @@ jobs:
       run: cargo test --all
     - name: Run the tests with x509-parser enabled
       run: cargo test --verbose --features x509-parser
+    - name: Run the tests with no default features enabled
+      run: cargo test --verbose --no-default-features
 
   coverage:
     name: Measure coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changes
 
+## Release 0.11.3 - Pending
+
+- Fix for import errors building without the optional `pem` feature.
+
 ## Release 0.11.2 - September 21, 2023
 
 - `rcgen` has joined the umbrella of the [rustls](https://github.com/rustls) organization.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,14 @@ name = "rcgen"
 path = "src/main.rs"
 required-features = ["pem"]
 
+[[example]]
+name = "rsa-irc"
+required-features = ["pem"]
+
+[[example]]
+name = "rsa-irc-openssl"
+required-features = ["pem"]
+
 [dependencies]
 yasna = { version = "0.5.2", features = ["time", "std"] }
 ring = "0.16"

--- a/examples/rsa-irc-openssl.rs
+++ b/examples/rsa-irc-openssl.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::complexity, clippy::style, clippy::pedantic)]
 
-use rcgen::{date_time_ymd, Certificate, CertificateParams, DistinguishedName};
-use std::convert::TryInto;
-use std::fs;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+	use rcgen::{date_time_ymd, Certificate, CertificateParams, DistinguishedName};
+	use std::fs;
+
 	let mut params: CertificateParams = Default::default();
 	params.not_before = date_time_ymd(2021, 05, 19);
 	params.not_after = date_time_ymd(4096, 01, 01);

--- a/examples/rsa-irc.rs
+++ b/examples/rsa-irc.rs
@@ -1,14 +1,13 @@
 #![allow(clippy::complexity, clippy::style, clippy::pedantic)]
 
-use rand::rngs::OsRng;
-use rsa::pkcs8::EncodePrivateKey;
-use rsa::RsaPrivateKey;
-
-use rcgen::{date_time_ymd, Certificate, CertificateParams, DistinguishedName};
-use std::convert::TryFrom;
-use std::fs;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+	use rand::rngs::OsRng;
+	use rsa::pkcs8::EncodePrivateKey;
+	use rsa::RsaPrivateKey;
+
+	use rcgen::{date_time_ymd, Certificate, CertificateParams, DistinguishedName};
+	use std::fs;
+
 	let mut params: CertificateParams = Default::default();
 	params.not_before = date_time_ymd(2021, 05, 19);
 	params.not_after = date_time_ymd(4096, 01, 01);

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -47,7 +47,6 @@ use crate::{
 ///   key_identifier_method: KeyIdMethod::Sha256,
 /// };
 /// let crl = CertificateRevocationList::from_params(crl).unwrap();
-/// println!("{}", crl.serialize_pem_with_signer(&issuer).unwrap());
 ///# }
 pub struct CertificateRevocationList {
 	params: CertificateRevocationListParams,

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -5,6 +5,7 @@ use yasna::DERWriter;
 use yasna::Tag;
 
 use crate::oid::*;
+#[cfg(feature = "pem")]
 use crate::ENCODE_CONFIG;
 use crate::{
 	write_distinguished_name, write_dt_utc_or_generalized, write_x509_authority_key_identifier,

--- a/src/key_pair.rs
+++ b/src/key_pair.rs
@@ -9,7 +9,9 @@ use yasna::DERWriter;
 
 use crate::sign_algo::algo::*;
 use crate::sign_algo::SignAlgo;
-use crate::{RcgenError, SignatureAlgorithm, ENCODE_CONFIG};
+#[cfg(feature = "pem")]
+use crate::ENCODE_CONFIG;
+use crate::{RcgenError, SignatureAlgorithm};
 
 /// A key pair vairant
 #[allow(clippy::large_enum_variant)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@ The most simple way of using this crate is by calling the
 [`generate_simple_self_signed`] function.
 For more customization abilities, we provide the lower level
 [`Certificate::from_params`] function.
-
+*/
+#![cfg_attr(
+	feature = "pem",
+	doc = r##"
 ## Example
 
 ```
@@ -22,9 +25,8 @@ let cert = generate_simple_self_signed(subject_alt_names).unwrap();
 println!("{}", cert.serialize_pem().unwrap());
 println!("{}", cert.serialize_private_key_pem());
 # }
-```
-*/
-
+```"##
+)]
 #![forbid(unsafe_code)]
 #![forbid(non_ascii_idents)]
 #![deny(missing_docs)]
@@ -74,7 +76,10 @@ Given a set of domain names you want your certificate to be valid for,
 this function fills in the other generation parameters with
 reasonable defaults and generates a self signed certificate
 as output.
-
+*/
+#[cfg_attr(
+	feature = "pem",
+	doc = r##"
 ## Example
 
 ```
@@ -90,7 +95,8 @@ println!("{}", cert.serialize_pem().unwrap());
 println!("{}", cert.serialize_private_key_pem());
 # }
 ```
-*/
+"##
+)]
 pub fn generate_simple_self_signed(
 	subject_alt_names: impl Into<Vec<String>>,
 ) -> Result<Certificate, RcgenError> {

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -1,50 +1,55 @@
 mod util;
 
-use rcgen::{Certificate, KeyPair, RcgenError};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+#[cfg(feature = "pem")]
+mod test_key_params_mismatch {
+	use crate::util;
 
-fn generate_hash<T: Hash>(subject: &T) -> u64 {
-	let mut hasher = DefaultHasher::new();
-	subject.hash(&mut hasher);
-	hasher.finish()
-}
+	use rcgen::{Certificate, KeyPair, RcgenError};
+	use std::collections::hash_map::DefaultHasher;
+	use std::hash::{Hash, Hasher};
 
-#[test]
-fn test_key_params_mismatch() {
-	let available_key_params = [
-		&rcgen::PKCS_RSA_SHA256,
-		&rcgen::PKCS_ECDSA_P256_SHA256,
-		&rcgen::PKCS_ECDSA_P384_SHA384,
-		&rcgen::PKCS_ED25519,
-	];
-	for (i, kalg_1) in available_key_params.iter().enumerate() {
-		for (j, kalg_2) in available_key_params.iter().enumerate() {
-			if i == j {
-				assert_eq!(*kalg_1, *kalg_2);
-				assert_eq!(generate_hash(*kalg_1), generate_hash(*kalg_2));
-				continue;
+	fn generate_hash<T: Hash>(subject: &T) -> u64 {
+		let mut hasher = DefaultHasher::new();
+		subject.hash(&mut hasher);
+		hasher.finish()
+	}
+
+	#[test]
+	fn test_key_params_mismatch() {
+		let available_key_params = [
+			&rcgen::PKCS_RSA_SHA256,
+			&rcgen::PKCS_ECDSA_P256_SHA256,
+			&rcgen::PKCS_ECDSA_P384_SHA384,
+			&rcgen::PKCS_ED25519,
+		];
+		for (i, kalg_1) in available_key_params.iter().enumerate() {
+			for (j, kalg_2) in available_key_params.iter().enumerate() {
+				if i == j {
+					assert_eq!(*kalg_1, *kalg_2);
+					assert_eq!(generate_hash(*kalg_1), generate_hash(*kalg_2));
+					continue;
+				}
+
+				assert_ne!(*kalg_1, *kalg_2);
+				assert_ne!(generate_hash(*kalg_1), generate_hash(*kalg_2));
+
+				let mut wrong_params = util::default_params();
+				if i != 0 {
+					wrong_params.key_pair = Some(KeyPair::generate(kalg_1).unwrap());
+				} else {
+					let kp = KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM).unwrap();
+					wrong_params.key_pair = Some(kp);
+				}
+				wrong_params.alg = *kalg_2;
+
+				assert_eq!(
+					Certificate::from_params(wrong_params).err(),
+					Some(RcgenError::CertificateKeyPairMismatch),
+					"i: {} j: {}",
+					i,
+					j
+				);
 			}
-
-			assert_ne!(*kalg_1, *kalg_2);
-			assert_ne!(generate_hash(*kalg_1), generate_hash(*kalg_2));
-
-			let mut wrong_params = util::default_params();
-			if i != 0 {
-				wrong_params.key_pair = Some(KeyPair::generate(kalg_1).unwrap());
-			} else {
-				let kp = KeyPair::from_pem(util::RSA_TEST_KEY_PAIR_PEM).unwrap();
-				wrong_params.key_pair = Some(kp);
-			}
-			wrong_params.alg = *kalg_2;
-
-			assert_eq!(
-				Certificate::from_params(wrong_params).err(),
-				Some(RcgenError::CertificateKeyPairMismatch),
-				"i: {} j: {}",
-				i,
-				j
-			);
 		}
 	}
 }
@@ -87,9 +92,8 @@ mod test_convert_x509_subject_alternative_name {
 #[cfg(feature = "x509-parser")]
 mod test_x509_custom_ext {
 	use crate::util;
-	use crate::Certificate;
 
-	use rcgen::CustomExtension;
+	use rcgen::{Certificate, CustomExtension};
 	use x509_parser::oid_registry::asn1_rs;
 	use x509_parser::prelude::{
 		FromDer, ParsedCriAttribute, X509Certificate, X509CertificationRequest,

--- a/tests/openssl.rs
+++ b/tests/openssl.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "pem")]
 use openssl::asn1::{Asn1Integer, Asn1Time};
 use openssl::bn::BigNum;
 use openssl::pkey::PKey;

--- a/tests/webpki.rs
+++ b/tests/webpki.rs
@@ -14,10 +14,9 @@ use webpki::{
 use webpki::{DnsNameRef, Time};
 
 use ring::rand::SystemRandom;
-use ring::signature::{
-	self, EcdsaKeyPair, EcdsaSigningAlgorithm, Ed25519KeyPair, KeyPair as _, RsaEncoding,
-	RsaKeyPair,
-};
+use ring::signature::{self, EcdsaKeyPair, EcdsaSigningAlgorithm, Ed25519KeyPair, KeyPair as _};
+#[cfg(feature = "pem")]
+use ring::signature::{RsaEncoding, RsaKeyPair};
 
 use std::convert::TryFrom;
 use time::{Duration, OffsetDateTime};
@@ -39,6 +38,7 @@ fn sign_msg_ed25519(cert: &Certificate, msg: &[u8]) -> Vec<u8> {
 	signature.as_ref().to_vec()
 }
 
+#[cfg(feature = "pem")]
 fn sign_msg_rsa(cert: &Certificate, msg: &[u8], encoding: &'static dyn RsaEncoding) -> Vec<u8> {
 	let pk_der = cert.serialize_private_key_der();
 	let key_pair = RsaKeyPair::from_pkcs8(&pk_der).unwrap();
@@ -56,7 +56,10 @@ fn check_cert<'a, 'b>(
 	alg: &SignatureAlgorithm,
 	sign_fn: impl FnOnce(&'a Certificate, &'b [u8]) -> Vec<u8>,
 ) {
-	println!("{}", cert.serialize_pem().unwrap());
+	#[cfg(feature = "pem")]
+	{
+		println!("{}", cert.serialize_pem().unwrap());
+	}
 	check_cert_ca(cert_der, cert, cert_der, alg, alg, sign_fn);
 }
 
@@ -154,6 +157,7 @@ fn test_webpki_25519() {
 	check_cert(&cert_der, &cert, &webpki::ED25519, &sign_msg_ed25519);
 }
 
+#[cfg(feature = "pem")]
 #[test]
 fn test_webpki_25519_v1_given() {
 	let mut params = util::default_params();
@@ -170,6 +174,7 @@ fn test_webpki_25519_v1_given() {
 	check_cert(&cert_der, &cert, &webpki::ED25519, &sign_msg_ed25519);
 }
 
+#[cfg(feature = "pem")]
 #[test]
 fn test_webpki_25519_v2_given() {
 	let mut params = util::default_params();
@@ -186,6 +191,7 @@ fn test_webpki_25519_v2_given() {
 	check_cert(&cert_der, &cert, &webpki::ED25519, &sign_msg_ed25519);
 }
 
+#[cfg(feature = "pem")]
 #[test]
 fn test_webpki_rsa_given() {
 	let mut params = util::default_params();
@@ -207,6 +213,7 @@ fn test_webpki_rsa_given() {
 	);
 }
 
+#[cfg(feature = "pem")]
 #[test]
 fn test_webpki_rsa_combinations_given() {
 	let configs: &[(_, _, &'static dyn signature::RsaEncoding)] = &[


### PR DESCRIPTION
In 0.11.2 the `src/crl.rs` and `src/key_pair.rs` modules were unconditionally importing `crate::ENCODE_CONFIG`, but this is only present when building with the optional `pem` feature. Additionally the crate example binaries, doc examples, and unit tests were often implicitly depending on `pem`, breaking compilation with `--no-default-features`.

This branch adds the correct import feature cfg gates, adds CI coverage for `--no-default-features` testing and clippy, fixes all of the various implicit `pem` dependencies, and updates `CHANGELOG.md` for a point release to include the fixes.

Resolves https://github.com/rustls/rcgen/issues/161