### PR TITLE
Rename `Error` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changes
 
+## Unreleased
+
+- Rename `RcGenError` to `Error` to avoid stuttering when used fully-qualified via `rcgen::`.
+
 ## Release 0.11.3 - October 1, 2023
 
 - Fix for import errors building without the optional `pem` feature.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,9 @@
-use std::error::Error;
 use std::fmt;
 
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 /// The error type of the rcgen crate
-pub enum RcgenError {
+pub enum Error {
 	/// The given certificate couldn't be parsed
 	CouldNotParseCertificate,
 	/// The given certificate signing request couldn't be parsed
@@ -46,9 +45,9 @@ pub enum RcgenError {
 	IssuerNotCrlSigner,
 }
 
-impl fmt::Display for RcgenError {
+impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		use self::RcgenError::*;
+		use self::Error::*;
 		match self {
 			CouldNotParseCertificate => write!(f, "Could not parse certificate")?,
 			CouldNotParseCertificationRequest => write!(
@@ -97,23 +96,23 @@ impl fmt::Display for RcgenError {
 	}
 }
 
-impl Error for RcgenError {}
+impl std::error::Error for Error {}
 
-impl From<ring::error::Unspecified> for RcgenError {
+impl From<ring::error::Unspecified> for Error {
 	fn from(_unspecified: ring::error::Unspecified) -> Self {
-		RcgenError::RingUnspecified
+		Error::RingUnspecified
 	}
 }
 
-impl From<ring::error::KeyRejected> for RcgenError {
+impl From<ring::error::KeyRejected> for Error {
 	fn from(err: ring::error::KeyRejected) -> Self {
-		RcgenError::RingKeyRejected(err.description_())
+		Error::RingKeyRejected(err.description_())
 	}
 }
 
 #[cfg(feature = "pem")]
-impl From<pem::PemError> for RcgenError {
+impl From<pem::PemError> for Error {
 	fn from(e: pem::PemError) -> Self {
-		RcgenError::PemError(e)
+		Error::PemError(e)
 	}
 }

--- a/src/sign_algo.rs
+++ b/src/sign_algo.rs
@@ -6,7 +6,7 @@ use yasna::DERWriter;
 use yasna::Tag;
 
 use crate::oid::*;
-use crate::RcgenError;
+use crate::Error;
 
 pub(crate) enum SignAlgo {
 	EcDsa(&'static EcdsaSigningAlgorithm),
@@ -90,13 +90,13 @@ impl SignatureAlgorithm {
 	}
 
 	/// Retrieve the SignatureAlgorithm for the provided OID
-	pub fn from_oid(oid: &[u64]) -> Result<&'static SignatureAlgorithm, RcgenError> {
+	pub fn from_oid(oid: &[u64]) -> Result<&'static SignatureAlgorithm, Error> {
 		for algo in Self::iter() {
 			if algo.oid_components == oid {
 				return Ok(algo);
 			}
 		}
-		Err(RcgenError::UnsupportedSignatureAlgorithm)
+		Err(Error::UnsupportedSignatureAlgorithm)
 	}
 }
 

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -4,7 +4,7 @@ mod util;
 mod test_key_params_mismatch {
 	use crate::util;
 
-	use rcgen::{Certificate, KeyPair, RcgenError};
+	use rcgen::{Certificate, Error, KeyPair};
 	use std::collections::hash_map::DefaultHasher;
 	use std::hash::{Hash, Hasher};
 
@@ -44,7 +44,7 @@ mod test_key_params_mismatch {
 
 				assert_eq!(
 					Certificate::from_params(wrong_params).err(),
-					Some(RcgenError::CertificateKeyPairMismatch),
+					Some(Error::CertificateKeyPairMismatch),
 					"i: {} j: {}",
 					i,
 					j

--- a/tests/webpki.rs
+++ b/tests/webpki.rs
@@ -321,12 +321,12 @@ fn from_remote() {
 			self.0.public_key().as_ref()
 		}
 
-		fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, rcgen::RcgenError> {
+		fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, rcgen::Error> {
 			let system_random = SystemRandom::new();
 			self.0
 				.sign(&system_random, msg)
 				.map(|s| s.as_ref().to_owned())
-				.map_err(rcgen::RcgenError::from)
+				.map_err(rcgen::Error::from)
 		}
 
 		fn algorithm(&self) -> &'static rcgen::SignatureAlgorithm {


### PR DESCRIPTION
Error types of upstream crates often need to be referred to in several places like composite `Error` enums. Having the type just named `Error` and exported at the root makes this really easy by just fully-qualifying it, in our case `rcgen::Error`. This saves the user from having to add an additional `use rcgen::` line and is unambiguous.

We provide a type-alias to make the rename a non-breaking change, meaning it can be released immediately before other breaking changes like the [upgrade to `ring 0.17`](https://github.com/rustls/rcgen/pull/166) for example.