### PR TITLE
ci: add caching w/ actions/cache@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,16 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+          $VCPKG_DEFAULT_BINARY_CACHE
+        key: ${{ runner.os }}-cargo-stable-${{ hashFiles('Cargo.lock') }}
     - uses: egor-tensin/vs-shell@v2
       with:
         arch: amd64
@@ -105,6 +115,15 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{matrix.toolchain}}-${{ hashFiles('Cargo.lock') }}
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
@@ -126,6 +145,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('Cargo.lock') }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install rust toolchain


### PR DESCRIPTION
A possible alternative to https://github.com/rustls/rcgen/pull/168. This commit adds a caching step to the `build-windows`, `build` and `coverage` jobs of the GitHub actions CI configuration.

We key based on:

1. Runner OS
2. Rust toolchain
3. Hash of Cargo.lock

This is largely 1:1 with the [Cache action Rust Cargo docs](https://github.com/actions/cache/blob/main/examples.md#rust---cargo), but for the Windows build we also include the `$VCPKG_DEFAULT_BINARY_CACHE` to cache the result of `vcpkg` installation.