### PR TITLE
Fix error compatibility alias

### DIFF
--- a/rcgen/CHANGELOG.md
+++ b/rcgen/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Unreleased
 
-- Rename `RcGenError` to `Error` to avoid stuttering when used fully-qualified via `rcgen::`.
+- Rename `RcgenError` to `Error` to avoid stuttering when used fully-qualified via `rcgen::`.
 - Upgrade to `ring` `v0.17`.
 
 ## Release 0.11.3 - October 1, 2023

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -67,7 +67,7 @@ pub use crate::sign_algo::SignatureAlgorithm;
 #[deprecated(
 	note = "Renamed to `Error`. We recommend to refer to it by fully-qualifying the crate: `rcgen::Error`."
 )]
-pub type RcGenError = Error;
+pub type RcgenError = Error;
 
 /// A self signed certificate together with signing keys
 pub struct Certificate {


### PR DESCRIPTION
In #167, the error type was renamed from RcgenError to rcgen::Error.

Make sure the compatibility alias uses the correct name.