### PR TITLE
basic Ia5String support for DistinguishedName values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ version = "0.11.3"
 description = "Rust X.509 certificate generator"
 repository = "https://github.com/rustls/rcgen"
 keywords = ["mkcert", "ca", "certificate"]
+
+# This greatly speeds up rsa key generation times
+# (only applies to the dev-dependency of rcgen because cargo
+# ignores profile overrides for non leaf packages)
+[profile.dev.package.num-bigint-dig]
+opt-level = 3

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -42,9 +42,3 @@ rustls-webpki = { version = "0.101.0", features = ["std"] }
 botan = { version = "0.10", features = ["vendored"] }
 rand = "0.8"
 rsa = "0.9"
-
-# This greatly speeds up rsa key generation times
-# (only applies to the dev-dependency because cargo
-# ignores profile overrides for non leaf packages)
-[profile.dev.package.num-bigint-dig]
-opt-level = 3

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -363,6 +363,8 @@ impl DnType {
 pub enum DnValue {
 	/// A string encoded using UCS-2
 	BmpString(Vec<u8>),
+	/// An ASCII string.
+	Ia5String(String),
 	/// An ASCII string containing only A-Z, a-z, 0-9, '()+,-./:=? and `<SPACE>`
 	PrintableString(String),
 	/// A string of characters from the T.61 character set
@@ -1414,6 +1416,7 @@ fn write_distinguished_name(writer: DERWriter, dn: &DistinguishedName) {
 						DnValue::BmpString(s) => writer
 							.next()
 							.write_tagged_implicit(TAG_BMPSTRING, |writer| writer.write_bytes(s)),
+						DnValue::Ia5String(s) => writer.next().write_ia5_string(s),
 						DnValue::PrintableString(s) => writer.next().write_printable_string(s),
 						DnValue::TeletexString(s) => writer
 							.next()

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -474,19 +474,19 @@ impl DistinguishedName {
 			let dn_type = DnType::from_oid(&attr_type_oid.collect::<Vec<_>>());
 			let data = attr.attr_value().data;
 			let dn_value = match attr.attr_value().header.tag() {
-				Tag::T61String => DnValue::TeletexString(data.into()),
+				Tag::BmpString => DnValue::BmpString(data.into()),
 				Tag::PrintableString => {
 					let data =
 						std::str::from_utf8(data).map_err(|_| Error::CouldNotParseCertificate)?;
 					DnValue::PrintableString(data.to_owned())
 				},
+				Tag::T61String => DnValue::TeletexString(data.into()),
 				Tag::UniversalString => DnValue::UniversalString(data.into()),
 				Tag::Utf8String => {
 					let data =
 						std::str::from_utf8(data).map_err(|_| Error::CouldNotParseCertificate)?;
 					DnValue::Utf8String(data.to_owned())
 				},
-				Tag::BmpString => DnValue::BmpString(data.into()),
 				_ => return Err(Error::CouldNotParseCertificate),
 			};
 

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -473,20 +473,15 @@ impl DistinguishedName {
 				.ok_or(Error::CouldNotParseCertificate)?;
 			let dn_type = DnType::from_oid(&attr_type_oid.collect::<Vec<_>>());
 			let data = attr.attr_value().data;
+			let try_str =
+				|data| std::str::from_utf8(data).map_err(|_| Error::CouldNotParseCertificate);
 			let dn_value = match attr.attr_value().header.tag() {
 				Tag::BmpString => DnValue::BmpString(data.into()),
-				Tag::PrintableString => {
-					let data =
-						std::str::from_utf8(data).map_err(|_| Error::CouldNotParseCertificate)?;
-					DnValue::PrintableString(data.to_owned())
-				},
+				Tag::Ia5String => DnValue::Ia5String(try_str(data)?.to_owned()),
+				Tag::PrintableString => DnValue::PrintableString(try_str(data)?.to_owned()),
 				Tag::T61String => DnValue::TeletexString(data.into()),
 				Tag::UniversalString => DnValue::UniversalString(data.into()),
-				Tag::Utf8String => {
-					let data =
-						std::str::from_utf8(data).map_err(|_| Error::CouldNotParseCertificate)?;
-					DnValue::Utf8String(data.to_owned())
-				},
+				Tag::Utf8String => DnValue::Utf8String(try_str(data)?.to_owned()),
 				_ => return Err(Error::CouldNotParseCertificate),
 			};
 

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -879,36 +879,7 @@ impl CertificateParams {
 			// Write version
 			writer.next().write_u8(0);
 			// Write issuer
-			writer.next().write_sequence(|writer| {
-				for (ty, content) in distinguished_name.iter() {
-					writer.next().write_set(|writer| {
-						writer.next().write_sequence(|writer| {
-							writer.next().write_oid(&ty.to_oid());
-							match content {
-								DnValue::BmpString(s) => writer
-									.next()
-									.write_tagged_implicit(TAG_BMPSTRING, |writer| {
-										writer.write_bytes(s)
-									}),
-								DnValue::PrintableString(s) => {
-									writer.next().write_printable_string(s)
-								},
-								DnValue::TeletexString(s) => writer
-									.next()
-									.write_tagged_implicit(TAG_TELETEXSTRING, |writer| {
-										writer.write_bytes(s)
-									}),
-								DnValue::UniversalString(s) => writer
-									.next()
-									.write_tagged_implicit(TAG_UNIVERSALSTRING, |writer| {
-										writer.write_bytes(s)
-									}),
-								DnValue::Utf8String(s) => writer.next().write_utf8_string(s),
-							}
-						});
-					});
-				}
-			});
+			write_distinguished_name(writer.next(), &distinguished_name);
 			// Write subjectPublicKeyInfo
 			pub_key.serialize_public_key_der(writer.next());
 			// Write extensions


### PR DESCRIPTION
This branch adds basic support emitting and parsing distinguished name values that are Ia5Strings. For example, email address attributes in a certificate subject distinguished name.

Note that because of #181 this code will panic when emitting invalid Ia5String values. This problem is general to rcgen's handling of ASN.1 string types and so isn't addressed with additional care in this branch. A broader rework is required.

Along the way I also fixed a warning from https://github.com/rustls/rcgen/pull/176 related to where we were defining the custom `profile.dev.package.num-bigint-dig` profile metadata.

Resolves #180 