### PR TITLE
Don't use workspace-wide crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ pem = { version = "3.0.2" }
 license = "MIT OR Apache-2.0"
 edition = "2021"
 readme = "README.md"
-version = "0.11.3"
 description = "Rust X.509 certificate generator"
 repository = "https://github.com/rustls/rcgen"
 keywords = ["mkcert", "ca", "certificate"]

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rcgen"
+version = "0.11.3"
 documentation = "https://docs.rs/rcgen"
-version.workspace = true
 description.workspace = true
 repository.workspace = true
 readme.workspace = true


### PR DESCRIPTION
Given that rustls-cert-gen already specifies its version number (such that only one crate actually uses the workspace `version`) and that version numbers are generally pretty closely tied to specific crate's API, IMO it's better to avoid having a workspace-level crate version.