### PR TITLE
codecov: disable comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,1 @@
-comment:
-  require_changes: true
+comment: false


### PR DESCRIPTION
Turn off codecov leaving comments on PRs based on the [doc suggestion](https://docs.codecov.com/docs/pull-request-comments#disable-comment).

Resolves https://github.com/rustls/rcgen/issues/186

