### PR TITLE
new `simple` example for rcgen

### DIFF
--- a/rcgen/examples/simple.rs
+++ b/rcgen/examples/simple.rs
@@ -1,0 +1,33 @@
+use rcgen::{date_time_ymd, Certificate, CertificateParams, DistinguishedName, DnType, SanType};
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let mut params: CertificateParams = Default::default();
+	params.not_before = date_time_ymd(1975, 1, 1);
+	params.not_after = date_time_ymd(4096, 1, 1);
+	params.distinguished_name = DistinguishedName::new();
+	params
+		.distinguished_name
+		.push(DnType::OrganizationName, "Crab widgits SE");
+	params
+		.distinguished_name
+		.push(DnType::CommonName, "Master Cert");
+	params.subject_alt_names = vec![
+		SanType::DnsName("crabs.crabs".to_string()),
+		SanType::DnsName("localhost".to_string()),
+	];
+
+	let cert = Certificate::from_params(params)?;
+
+	let pem_serialized = cert.serialize_pem()?;
+	let pem = pem::parse(&pem_serialized)?;
+	let der_serialized = pem.contents();
+	println!("{pem_serialized}");
+	println!("{}", cert.serialize_private_key_pem());
+	fs::create_dir_all("certs/")?;
+	fs::write("certs/cert.pem", pem_serialized.as_bytes())?;
+	fs::write("certs/cert.der", der_serialized)?;
+	fs::write("certs/key.pem", cert.serialize_private_key_pem().as_bytes())?;
+	fs::write("certs/key.der", cert.serialize_private_key_der())?;
+	Ok(())
+}


### PR DESCRIPTION
This takes what was formerly `rcgen/src/main.rs` and moves it to the examples folder as `simple.rs`. It was split off from #185