### PR TITLE
ensure default serial generation fits 20 bytes

### DIFF
--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -937,8 +937,9 @@ impl CertificateParams {
 			} else {
 				let hash = digest::digest(&digest::SHA256, pub_key.raw_bytes());
 				// RFC 5280 specifies at most 20 bytes for a serial number
-				let sl = &hash.as_ref()[0..20];
-				writer.next().write_bigint_bytes(sl, true);
+				let mut sl = hash.as_ref()[0..20].to_vec();
+				sl[0] = sl[0] & 0x7f; // MSB must be 0 to ensure encoding bignum in 20 bytes
+				writer.next().write_bigint_bytes(&sl, true);
 			};
 			// Write signature
 			ca.params.alg.write_alg_ident(writer.next());


### PR DESCRIPTION
By default, s/n is generated taking digest of pub-key of the certificate.

However, if the slice number representation is a negative number, then `write_bigint_bytes` is going to append an additional `0`-byte to ensure the positive sign.

See: https://github.com/qnighy/yasna.rs/blob/b7e65f9a4c317494cce2d18ea02b3d6eaaea7985/src/writer/mod.rs#L493-L495

So it is possible the bigint encoding will take 21 bytes instead of 20.

This CR sets MSB of digest to `0` to ensure encoding will take exactly 20 bytes