### PR TITLE
Allow building without the `pem` crate feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - --all-features
+          - --no-default-features --features ring
+          - --no-default-features --features aws_lc_rs
+          - --no-default-features --features aws_lc_rs,pem
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -38,8 +45,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --all-features --all-targets
-      - run: cargo clippy --no-default-features --features aws_lc_rs,pem --all-targets
+      - run: cargo clippy ${{ matrix.features }} --all-targets
 
   rustdoc:
     name: Documentation

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -387,6 +387,7 @@ impl<T> ExternalError<T> for Result<T, ring_error::Unspecified> {
 	}
 }
 
+#[cfg(feature = "pem")]
 impl<T> ExternalError<T> for Result<T, pem::PemError> {
 	fn _err(self) -> Result<T, Error> {
 		self.map_err(|e| Error::PemError(e.to_string()))

--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -7,5 +7,5 @@ edition.workspace = true
 keywords.workspace = true
 
 [dependencies]
-rcgen = { path = "../rcgen", default-features = false }
+rcgen = { path = "../rcgen", default-features = false, features = ["pem"] }
 pem = { workspace = true }


### PR DESCRIPTION
Currently trying to build like this:
```
cargo build -p rcgen --no-default-features --features ring
```
will fail because it can't find `pem::PemError` or `Error::PemError`.

Simply adding a `cfg` guard on this implementation fixes the issue.