### PR TITLE
choose a crypto_provider for rustls_cert_gen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,21 @@ jobs:
     - name: Run the tests with aws_lc_rs backend enabled
       run: cargo test --verbose --no-default-features --features aws_lc_rs,pem --all-targets
 
+  # Build rustls-cert-gen as a standalone package, see this PR for why it's needed:
+  # https://github.com/rustls/rcgen/pull/206#pullrequestreview-1816197358
+  build-rustls-cert-gen-standalone:
+    name: Build rustls-cert-gen as a standalone package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run the tests
+        run: cargo test --package rustls-cert-gen
+
   coverage:
     name: Measure coverage
     runs-on: ubuntu-latest

--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 
 [dependencies]
-rcgen = { path = "../rcgen", default-features = false, features = ["pem"] }
+rcgen = { path = "../rcgen", default-features = false, features = ["pem", "ring"] }
 bpaf = { version = "0.9.5", features = ["derive"] }
 pem = { workspace = true }
 ring = { workspace = true }


### PR DESCRIPTION
From the release 0.12 of rcgen https://github.com/rustls/rcgen/pull/202 , we must now choose `ring` or `aws_lc_rc` as a feature.
Because `rustls_cert_gen` has `default-features = false`,  its build is currently broken.

~This PR activate  `aws_lc_rc` feature, because soon it will get RSA key generation support https://github.com/aws/aws-lc-rs/issues/296 , so it will provide more options.~ Edit: we switched to using ring to match the rcgen default.

But we could also change it to default to whatever `rcgen` default or use `ring` as default depending on your preferences.