### PR TITLE
Support compiling without cryptography primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,30 +157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "botan"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350081af1a3c6883f8a1f863ac553bfe6922589aad60008a70947765ed57c53e"
-dependencies = [
- "botan-sys",
-]
-
-[[package]]
-name = "botan-src"
-version = "0.30101.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaaf0426c00371ec87f150daa40f3a8f149c6e8b9646d5fafa30888cacb2bc9f"
-
-[[package]]
-name = "botan-sys"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f49dde1b8ebd2996cc41c55c39f6ef8b54e38148d8973aeba0792b87b1621ca"
-dependencies = [
- "botan-src",
-]
-
-[[package]]
 name = "bpaf"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,7 +841,6 @@ name = "rcgen"
 version = "0.12.0"
 dependencies = [
  "aws-lc-rs",
- "botan",
  "openssl",
  "pem",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "botan"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350081af1a3c6883f8a1f863ac553bfe6922589aad60008a70947765ed57c53e"
+dependencies = [
+ "botan-sys",
+]
+
+[[package]]
+name = "botan-src"
+version = "0.30101.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaf0426c00371ec87f150daa40f3a8f149c6e8b9646d5fafa30888cacb2bc9f"
+
+[[package]]
+name = "botan-sys"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f49dde1b8ebd2996cc41c55c39f6ef8b54e38148d8973aeba0792b87b1621ca"
+dependencies = [
+ "botan-src",
+]
+
+[[package]]
 name = "bpaf"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +865,7 @@ name = "rcgen"
 version = "0.12.0"
 dependencies = [
  "aws-lc-rs",
+ "botan",
  "openssl",
  "pem",
  "rand",

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -31,7 +31,7 @@ x509-parser = { workspace = true, features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }
 
 [features]
-default = ["crypto", "random", "pem", "ring"]
+default = ["crypto", "pem", "ring"]
 crypto = ["random"]
 random = []
 aws_lc_rs = ["dep:aws-lc-rs"]
@@ -51,7 +51,7 @@ allowed_external_types = [
 openssl = "0.10"
 x509-parser = { workspace = true, features = ["verify"] }
 rustls-webpki = { version = "0.101.0", features = ["std"] }
-#botan = { version = "0.10", features = ["vendored"] }
+botan = { version = "0.10", features = ["vendored"] }
 rand = { workspace = true }
 rsa = "0.9"
 ring = { workspace = true }

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -31,7 +31,9 @@ x509-parser = { workspace = true, features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }
 
 [features]
-default = ["pem", "ring"]
+default = ["crypto", "random", "pem", "ring"]
+crypto = ["random"]
+random = []
 aws_lc_rs = ["dep:aws-lc-rs"]
 ring = ["dep:ring"]
 
@@ -49,7 +51,7 @@ allowed_external_types = [
 openssl = "0.10"
 x509-parser = { workspace = true, features = ["verify"] }
 rustls-webpki = { version = "0.101.0", features = ["std"] }
-botan = { version = "0.10", features = ["vendored"] }
+#botan = { version = "0.10", features = ["vendored"] }
 rand = { workspace = true }
 rsa = "0.9"
 ring = { workspace = true }

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -9,8 +9,9 @@ use crate::error::ExternalError;
 use crate::ring_like::error as ring_error;
 #[cfg(feature = "random")]
 use crate::ring_like::rand::SystemRandom;
+#[cfg(feature = "random")]
 use crate::ring_like::signature::{KeyPair as RingKeyPair, Ed25519KeyPair};
-// #[cfg(feature = "random")]
+#[cfg(feature = "random")]
 use crate::ring_like::signature::EcdsaKeyPair;
 #[cfg(feature = "crypto")]
 use crate::ring_like::signature::{

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -10,13 +10,11 @@ use crate::ring_like::error as ring_error;
 #[cfg(feature = "random")]
 use crate::ring_like::rand::SystemRandom;
 #[cfg(feature = "random")]
-use crate::ring_like::signature::{KeyPair as RingKeyPair, Ed25519KeyPair};
-#[cfg(feature = "random")]
 use crate::ring_like::signature::EcdsaKeyPair;
 #[cfg(feature = "crypto")]
-use crate::ring_like::signature::{
-	self, RsaEncoding, RsaKeyPair,
-};
+use crate::ring_like::signature::{self, RsaEncoding, RsaKeyPair};
+#[cfg(feature = "random")]
+use crate::ring_like::signature::{Ed25519KeyPair, KeyPair as RingKeyPair};
 #[cfg(feature = "crypto")]
 use crate::ring_like::{ecdsa_from_pkcs8, rsa_key_pair_public_modulus_len};
 #[cfg(feature = "crypto")]
@@ -203,7 +201,6 @@ impl KeyPair {
 	/// DOC
 	#[cfg(feature = "crypto")]
 	pub fn generate(alg: &'static SignatureAlgorithm) -> Result<Self, Error> {
-
 		let rng = &SystemRandom::new();
 
 		match alg.sign_alg {

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -35,6 +35,7 @@ println!("{}", cert.serialize_private_key_pem());
 
 #[cfg(feature = "pem")]
 use pem::Pem;
+#[cfg(feature = "crypto")]
 use ring_like::digest;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -116,6 +117,7 @@ mod csr;
 mod error;
 mod key_pair;
 mod oid;
+#[cfg(feature = "crypto")]
 mod ring_like;
 mod sign_algo;
 

--- a/rcgen/src/ring_like.rs
+++ b/rcgen/src/ring_like.rs
@@ -4,9 +4,12 @@ pub(crate) use ring::*;
 #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
 pub(crate) use aws_lc_rs::*;
 
+#[cfg(feature = "crypto")]
 use crate::error::ExternalError;
+#[cfg(feature = "crypto")]
 use crate::Error;
 
+#[cfg(feature = "crypto")]
 pub(crate) fn ecdsa_from_pkcs8(
 	alg: &'static signature::EcdsaSigningAlgorithm,
 	pkcs8: &[u8],
@@ -23,6 +26,7 @@ pub(crate) fn ecdsa_from_pkcs8(
 	}
 }
 
+#[cfg(feature = "crypto")]
 pub(crate) fn rsa_key_pair_public_modulus_len(kp: &signature::RsaKeyPair) -> usize {
 	#[cfg(feature = "ring")]
 	{

--- a/rcgen/tests/generic.rs
+++ b/rcgen/tests/generic.rs
@@ -1,6 +1,6 @@
 mod util;
 
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "pem", feature = "crypto"))]
 mod test_key_params_mismatch {
 	use crate::util;
 

--- a/rcgen/tests/openssl.rs
+++ b/rcgen/tests/openssl.rs
@@ -229,6 +229,7 @@ fn test_openssl_25519() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn test_openssl_25519_v1_given() {
 	let mut params = util::default_params();
 	params.alg = &rcgen::PKCS_ED25519;
@@ -251,6 +252,7 @@ fn test_openssl_25519_v1_given() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn test_openssl_25519_v2_given() {
 	let mut params = util::default_params();
 	params.alg = &rcgen::PKCS_ED25519;
@@ -269,6 +271,7 @@ fn test_openssl_25519_v2_given() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn test_openssl_rsa_given() {
 	let mut params = util::default_params();
 	params.alg = &rcgen::PKCS_RSA_SHA256;
@@ -284,6 +287,7 @@ fn test_openssl_rsa_given() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn test_openssl_rsa_combinations_given() {
 	let alg_list = [
 		&rcgen::PKCS_RSA_SHA256,

--- a/rcgen/tests/webpki.rs
+++ b/rcgen/tests/webpki.rs
@@ -13,9 +13,12 @@ use webpki::{
 };
 use webpki::{DnsNameRef, Time};
 
+#[cfg(feature = "random")]
 use ring::rand::SystemRandom;
+#[cfg(feature = "crypto")]
 use ring::signature::{self, EcdsaKeyPair, EcdsaSigningAlgorithm, Ed25519KeyPair, KeyPair as _};
-#[cfg(feature = "pem")]
+
+#[cfg(all(feature = "pem", feature = "crypto"))]
 use ring::signature::{RsaEncoding, RsaKeyPair};
 
 use std::convert::TryFrom;
@@ -23,6 +26,7 @@ use time::{Duration, OffsetDateTime};
 
 mod util;
 
+#[cfg(all(feature = "random", feature ="crypto"))]
 fn sign_msg_ecdsa(cert: &Certificate, msg: &[u8], alg: &'static EcdsaSigningAlgorithm) -> Vec<u8> {
 	let pk_der = cert.serialize_private_key_der();
 	let key_pair =
@@ -32,6 +36,7 @@ fn sign_msg_ecdsa(cert: &Certificate, msg: &[u8], alg: &'static EcdsaSigningAlgo
 	signature.as_ref().to_vec()
 }
 
+#[cfg(all(feature = feature ="crypto"))]
 fn sign_msg_ed25519(cert: &Certificate, msg: &[u8]) -> Vec<u8> {
 	let pk_der = cert.serialize_private_key_der();
 	let key_pair = Ed25519KeyPair::from_pkcs8_maybe_unchecked(&pk_der).unwrap();
@@ -39,7 +44,7 @@ fn sign_msg_ed25519(cert: &Certificate, msg: &[u8]) -> Vec<u8> {
 	signature.as_ref().to_vec()
 }
 
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "pem", feature = "crypto"))]
 fn sign_msg_rsa(cert: &Certificate, msg: &[u8], encoding: &'static dyn RsaEncoding) -> Vec<u8> {
 	let pk_der = cert.serialize_private_key_der();
 	let key_pair = RsaKeyPair::from_pkcs8(&pk_der).unwrap();
@@ -105,6 +110,7 @@ fn check_cert_ca<'a, 'b>(
 		.expect("signature is valid");
 }
 
+#[cfg(all(feature = "crypto"))]
 #[test]
 fn test_webpki() {
 	let params = util::default_params();
@@ -117,6 +123,7 @@ fn test_webpki() {
 	check_cert(&cert_der, &cert, &webpki::ECDSA_P256_SHA256, sign_fn);
 }
 
+#[cfg(all(feature = "crypto"))]
 #[test]
 fn test_webpki_256() {
 	let mut params = util::default_params();
@@ -131,6 +138,7 @@ fn test_webpki_256() {
 	check_cert(&cert_der, &cert, &webpki::ECDSA_P256_SHA256, sign_fn);
 }
 
+#[cfg(all(feature = "crypto"))]
 #[test]
 fn test_webpki_384() {
 	let mut params = util::default_params();
@@ -145,6 +153,7 @@ fn test_webpki_384() {
 	check_cert(&cert_der, &cert, &webpki::ECDSA_P384_SHA384, sign_fn);
 }
 
+#[cfg(all(feature = "crypto"))]
 #[test]
 fn test_webpki_25519() {
 	let mut params = util::default_params();
@@ -158,7 +167,7 @@ fn test_webpki_25519() {
 	check_cert(&cert_der, &cert, &webpki::ED25519, sign_msg_ed25519);
 }
 
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "pem", feature = "crypto"))]
 #[test]
 fn test_webpki_25519_v1_given() {
 	let mut params = util::default_params();
@@ -175,7 +184,7 @@ fn test_webpki_25519_v1_given() {
 	check_cert(&cert_der, &cert, &webpki::ED25519, sign_msg_ed25519);
 }
 
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "pem", feature = "crypto"))]
 #[test]
 fn test_webpki_25519_v2_given() {
 	let mut params = util::default_params();
@@ -192,7 +201,7 @@ fn test_webpki_25519_v2_given() {
 	check_cert(&cert_der, &cert, &webpki::ED25519, sign_msg_ed25519);
 }
 
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "pem", feature = "crypto"))]
 #[test]
 fn test_webpki_rsa_given() {
 	let mut params = util::default_params();
@@ -214,7 +223,7 @@ fn test_webpki_rsa_given() {
 	);
 }
 
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "pem", feature = "crypto"))]
 #[test]
 fn test_webpki_rsa_combinations_given() {
 	let configs: &[(_, _, &'static dyn signature::RsaEncoding)] = &[
@@ -252,6 +261,7 @@ fn test_webpki_rsa_combinations_given() {
 	}
 }
 
+#[cfg(all(feature = "crypto"))]
 #[test]
 fn test_webpki_separate_ca() {
 	let mut params = util::default_params();
@@ -313,6 +323,7 @@ fn test_webpki_separate_ca_with_other_signing_alg() {
 	);
 }
 
+#[cfg(all(feature = "pem", feature = "crypto"))]
 #[test]
 fn from_remote() {
 	struct Remote(EcdsaKeyPair);
@@ -518,6 +529,7 @@ fn test_certificate_from_csr() {
 	);
 }
 
+#[cfg(all(feature = "crypto"))]
 #[test]
 fn test_webpki_serial_number() {
 	let mut params = util::default_params();

--- a/rcgen/tests/webpki.rs
+++ b/rcgen/tests/webpki.rs
@@ -26,7 +26,7 @@ use time::{Duration, OffsetDateTime};
 
 mod util;
 
-#[cfg(all(feature = "random", feature ="crypto"))]
+#[cfg(all(feature = "random", feature = "crypto"))]
 fn sign_msg_ecdsa(cert: &Certificate, msg: &[u8], alg: &'static EcdsaSigningAlgorithm) -> Vec<u8> {
 	let pk_der = cert.serialize_private_key_der();
 	let key_pair =

--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 
 [dependencies]
-rcgen = { path = "../rcgen", default-features = false, features = ["pem"] }
+rcgen = { path = "../rcgen", default-features = false, features = ["pem", "crypto", "random"] }
 bpaf = { version = "0.9.5", features = ["derive"] }
 pem = { workspace = true }
 ring = { workspace = true }

--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -6,8 +6,12 @@ license.workspace = true
 edition.workspace = true
 keywords.workspace = true
 
+[features]
+default = ["crypto"]
+crypto = ["rcgen/crypto"]
+
 [dependencies]
-rcgen = { path = "../rcgen", default-features = false, features = ["pem", "crypto", "random"] }
+rcgen = { path = "../rcgen", default-features = false, features = ["pem"] }
 bpaf = { version = "0.9.5", features = ["derive"] }
 pem = { workspace = true }
 ring = { workspace = true }

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "crypto")]
 use bpaf::Bpaf;
 use rcgen::{
 	BasicConstraints, Certificate, CertificateParams, DistinguishedName, DnType,
 	DnValue::PrintableString, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose, SanType,
 };
-use std::{fmt, fs::File, io, path::Path};
+use std::{fs::File, io, path::Path};
+#[cfg(feature = "crypto")]
+use std::fmt;
 
 #[derive(Debug, Clone)]
 /// PEM serialized Certificate and PEM serialized corresponding private key
@@ -196,6 +199,7 @@ impl EndEntityBuilder {
 	}
 }
 
+#[cfg(feature = "crypto")]
 #[derive(Clone, Debug, Bpaf)]
 /// Supported Keypair Algorithms
 pub enum KeypairAlgorithm {
@@ -204,6 +208,7 @@ pub enum KeypairAlgorithm {
 	EcdsaP384,
 }
 
+#[cfg(feature = "crypto")]
 impl fmt::Display for KeypairAlgorithm {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
@@ -314,6 +319,8 @@ mod tests {
 
 		Ok(())
 	}
+	
+	#[cfg(feature = "crypto")]
 	#[test]
 	fn serialize_end_entity_ecdsa_p384_sha384_sig() -> anyhow::Result<()> {
 		let ca = CertificateBuilder::new().certificate_authority().build()?;
@@ -333,6 +340,7 @@ mod tests {
 		Ok(())
 	}
 
+	#[cfg(feature = "crypto")]
 	#[test]
 	fn serialize_end_entity_ed25519_sig() -> anyhow::Result<()> {
 		let ca = CertificateBuilder::new().certificate_authority().build()?;
@@ -417,6 +425,7 @@ mod tests {
 		assert_eq!(cert.params.subject_alt_names, vec![]);
 	}
 
+	#[cfg(feature = "crypto")]
 	#[test]
 	fn keypair_algorithm_to_keypair() -> anyhow::Result<()> {
 		let keypair = KeypairAlgorithm::Ed25519.to_keypair()?;

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -50,6 +50,7 @@ impl CertificateBuilder {
 		Self { params }
 	}
 	/// Set signature algorithm (instead of default).
+	#[cfg(feature = "crypto")]
 	pub fn signature_algorithm(mut self, alg: &KeypairAlgorithm) -> anyhow::Result<Self> {
 		let keypair = alg.to_keypair()?;
 		self.params.alg = keypair.algorithm();
@@ -213,6 +214,7 @@ impl fmt::Display for KeypairAlgorithm {
 	}
 }
 
+#[cfg(feature = "crypto")]
 impl KeypairAlgorithm {
 	/// Return an `rcgen::KeyPair` for the given varient
 	fn to_keypair(&self) -> Result<rcgen::KeyPair, rcgen::Error> {

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -4,9 +4,9 @@ use rcgen::{
 	BasicConstraints, Certificate, CertificateParams, DistinguishedName, DnType,
 	DnValue::PrintableString, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose, SanType,
 };
-use std::{fs::File, io, path::Path};
 #[cfg(feature = "crypto")]
 use std::fmt;
+use std::{fs::File, io, path::Path};
 
 #[derive(Debug, Clone)]
 /// PEM serialized Certificate and PEM serialized corresponding private key
@@ -319,7 +319,7 @@ mod tests {
 
 		Ok(())
 	}
-	
+
 	#[cfg(feature = "crypto")]
 	#[test]
 	fn serialize_end_entity_ecdsa_p384_sha384_sig() -> anyhow::Result<()> {

--- a/rustls-cert-gen/src/main.rs
+++ b/rustls-cert-gen/src/main.rs
@@ -1,9 +1,12 @@
 use bpaf::Bpaf;
 use rcgen::SanType;
-use std::{net::IpAddr, path::PathBuf};
+use std::net::IpAddr;
+use std::path::PathBuf;
 
 mod cert;
-use cert::{keypair_algorithm, CertificateBuilder, KeypairAlgorithm};
+use cert::CertificateBuilder;
+#[cfg(feature = "crypto")]
+use cert::{keypair_algorithm, KeypairAlgorithm};
 
 fn main() -> anyhow::Result<()> {
 	let opts = options().run();
@@ -19,7 +22,7 @@ fn main() -> anyhow::Result<()> {
 
 	let entity = CertificateBuilder::new();
 	#[cfg(feature = "crypto")]
-	let mut entity = entity.signature_algorithm(&opts.keypair_algorithm)?;
+	let entity = entity.signature_algorithm(&opts.keypair_algorithm)?;
 	let mut entity = entity
 		.end_entity()
 		.common_name(&opts.common_name)
@@ -43,7 +46,7 @@ fn main() -> anyhow::Result<()> {
 
 	Ok(())
 }
-
+/// #[cfg(feature = "crypto")]
 #[derive(Clone, Debug, Bpaf)]
 #[bpaf(options)]
 /// rustls-cert-gen TLS Certificate Generator
@@ -52,12 +55,14 @@ struct Options {
 	#[bpaf(short, long, argument("output/path/"))]
 	pub output: PathBuf,
 	/// Keypair algorithm
+	#[cfg(feature = "crypto")]
 	#[bpaf(
 		external(keypair_algorithm),
 		fallback(KeypairAlgorithm::EcdsaP256),
 		display_fallback,
 		group_help("Keypair Algorithm:")
 	)]
+	#[cfg(feature = "crypto")]
 	pub keypair_algorithm: KeypairAlgorithm,
 	/// Extended Key Usage Purpose: ClientAuth
 	#[bpaf(long)]

--- a/rustls-cert-gen/src/main.rs
+++ b/rustls-cert-gen/src/main.rs
@@ -8,15 +8,19 @@ use cert::{keypair_algorithm, CertificateBuilder, KeypairAlgorithm};
 fn main() -> anyhow::Result<()> {
 	let opts = options().run();
 
-	let ca = CertificateBuilder::new()
-		.signature_algorithm(&opts.keypair_algorithm)?
+	let ca = CertificateBuilder::new();
+	#[cfg(feature = "crypto")]
+	let ca = ca.signature_algorithm(&opts.keypair_algorithm)?;
+	let ca = ca
 		.certificate_authority()
 		.country_name(&opts.country_name)
 		.organization_name(&opts.organization_name)
 		.build()?;
 
-	let mut entity = CertificateBuilder::new()
-		.signature_algorithm(&opts.keypair_algorithm)?
+	let entity = CertificateBuilder::new();
+	#[cfg(feature = "crypto")]
+	let mut entity = entity.signature_algorithm(&opts.keypair_algorithm)?;
+	let mut entity = entity
 		.end_entity()
 		.common_name(&opts.common_name)
 		.subject_alternative_names(opts.san);


### PR DESCRIPTION
This makes all of the crypto libraries optional. My use case requires simply generating the binary ASN.1 structures and all cryptography is handled externally with HSMs.

This change removes unnecessary code and build complexity (for example, I'm targeting WASM, and I need to take extra steps to build the dependencies I don't need).

This change may still require some adjustments.