### PR TITLE
Support compiling without cryptography primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         features:
           - --all-features
+          - --no-default-features
           - --no-default-features --features ring
           - --no-default-features --features aws_lc_rs
           - --no-default-features --features aws_lc_rs,pem
@@ -137,6 +138,8 @@ jobs:
       run: cargo test --verbose --features x509-parser --all-targets
     - name: Run the tests with aws_lc_rs backend enabled
       run: cargo test --verbose --no-default-features --features aws_lc_rs,pem --all-targets
+    - name: Run the tests with no features enabled
+      run: cargo test --verbose --no-default-features --all-targets
 
   build:
     strategy:

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -21,6 +21,10 @@ required-features = ["pem"]
 name = "sign-leaf-with-ca"
 required-features = ["pem", "x509-parser"]
 
+[[example]]
+name = "simple"
+required-features = ["crypto"]
+
 [dependencies]
 aws-lc-rs = { version = "1.0.0", optional = true }
 yasna = { version = "0.5.2", features = ["time", "std"] }
@@ -31,9 +35,10 @@ x509-parser = { workspace = true, features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }
 
 [features]
-default = ["pem", "ring"]
-aws_lc_rs = ["dep:aws-lc-rs"]
-ring = ["dep:ring"]
+default = ["crypto", "pem", "ring"]
+crypto = []
+aws_lc_rs = ["crypto", "dep:aws-lc-rs"]
+ring = ["crypto", "dep:ring"]
 
 
 [package.metadata.docs.rs]

--- a/rcgen/src/error.rs
+++ b/rcgen/src/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
 	InvalidCrlNextUpdate,
 	/// CRL issuer specifies Key Usages that don't include cRLSign.
 	IssuerNotCrlSigner,
+	#[cfg(not(feature = "crypto"))]
+	/// Missing serial number
+	MissingSerialNumber,
 }
 
 impl fmt::Display for Error {
@@ -86,6 +89,8 @@ impl fmt::Display for Error {
 				f,
 				"CRL issuer must specify no key usage, or key usage including cRLSign"
 			)?,
+			#[cfg(not(feature = "crypto"))]
+			MissingSerialNumber => write!(f, "A serial number must be specified")?,
 		};
 		Ok(())
 	}

--- a/rcgen/src/ring_like.rs
+++ b/rcgen/src/ring_like.rs
@@ -1,12 +1,15 @@
-#[cfg(feature = "ring")]
+#[cfg(all(feature = "crypto", feature = "ring"))]
 pub(crate) use ring::*;
 
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[cfg(all(feature = "crypto", not(feature = "ring"), feature = "aws_lc_rs"))]
 pub(crate) use aws_lc_rs::*;
 
+#[cfg(feature = "crypto")]
 use crate::error::ExternalError;
+#[cfg(feature = "crypto")]
 use crate::Error;
 
+#[cfg(feature = "crypto")]
 pub(crate) fn ecdsa_from_pkcs8(
 	alg: &'static signature::EcdsaSigningAlgorithm,
 	pkcs8: &[u8],
@@ -23,6 +26,7 @@ pub(crate) fn ecdsa_from_pkcs8(
 	}
 }
 
+#[cfg(feature = "crypto")]
 pub(crate) fn rsa_key_pair_public_modulus_len(kp: &signature::RsaKeyPair) -> usize {
 	#[cfg(feature = "ring")]
 	{
@@ -35,5 +39,5 @@ pub(crate) fn rsa_key_pair_public_modulus_len(kp: &signature::RsaKeyPair) -> usi
 	}
 }
 
-#[cfg(not(any(feature = "ring", feature = "aws_lc_rs")))]
-compile_error!("At least one of the 'ring' or 'aws_lc_rs' features must be activated");
+#[cfg(all(feature = "crypto", not(any(feature = "ring", feature = "aws_lc_rs"))))]
+compile_error!("At least one of the 'ring' or 'aws_lc_rs' features must be activated when the 'crypto' feature is enabled");

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -4,17 +4,18 @@ use yasna::models::ObjectIdentifier;
 use yasna::DERWriter;
 use yasna::Tag;
 
-use crate::oid::*;
+#[cfg(feature = "crypto")]
 use crate::ring_like::signature::{self, EcdsaSigningAlgorithm, EdDSAParameters};
 use crate::Error;
 
+#[cfg(feature = "crypto")]
 pub(crate) enum SignAlgo {
 	EcDsa(&'static EcdsaSigningAlgorithm),
 	EdDsa(&'static EdDSAParameters),
 	Rsa(),
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Hash)]
 pub(crate) enum SignatureAlgorithmParams {
 	/// Omit the parameters
 	None,
@@ -30,6 +31,7 @@ pub(crate) enum SignatureAlgorithmParams {
 /// Signature algorithm type
 pub struct SignatureAlgorithm {
 	oids_sign_alg: &'static [&'static [u64]],
+	#[cfg(feature = "crypto")]
 	pub(crate) sign_alg: SignAlgo,
 	oid_components: &'static [u64],
 	params: SignatureAlgorithmParams,
@@ -73,7 +75,6 @@ impl Hash for SignatureAlgorithm {
 		self.oids_sign_alg.hash(state);
 	}
 }
-
 impl SignatureAlgorithm {
 	pub(crate) fn iter() -> std::slice::Iter<'static, &'static SignatureAlgorithm> {
 		use algo::*;
@@ -102,11 +103,14 @@ impl SignatureAlgorithm {
 
 /// The list of supported signature algorithms
 pub mod algo {
+	use crate::oid::*;
+
 	use super::*;
 
 	/// RSA signing with PKCS#1 1.5 padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static PKCS_RSA_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[&OID_RSA_ENCRYPTION],
+		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(),
 		// sha256WithRSAEncryption in RFC 4055
 		oid_components: &[1, 2, 840, 113549, 1, 1, 11],
@@ -116,6 +120,7 @@ pub mod algo {
 	/// RSA signing with PKCS#1 1.5 padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static PKCS_RSA_SHA384: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[&OID_RSA_ENCRYPTION],
+		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(),
 		// sha384WithRSAEncryption in RFC 4055
 		oid_components: &[1, 2, 840, 113549, 1, 1, 12],
@@ -125,6 +130,7 @@ pub mod algo {
 	/// RSA signing with PKCS#1 1.5 padding and SHA-512 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static PKCS_RSA_SHA512: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[&OID_RSA_ENCRYPTION],
+		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(),
 		// sha512WithRSAEncryption in RFC 4055
 		oid_components: &[1, 2, 840, 113549, 1, 1, 13],
@@ -141,6 +147,7 @@ pub mod algo {
 		// We could also use OID_RSA_ENCRYPTION here, but it's recommended
 		// to use ID-RSASSA-PSS if possible.
 		oids_sign_alg: &[&OID_RSASSA_PSS],
+		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(),
 		oid_components: &OID_RSASSA_PSS, //&[1, 2, 840, 113549, 1, 1, 13],
 		// rSASSA-PSS-SHA256-Params in RFC 4055
@@ -154,6 +161,7 @@ pub mod algo {
 	/// ECDSA signing using the P-256 curves and SHA-256 hashing as per [RFC 5758](https://tools.ietf.org/html/rfc5758#section-3.2)
 	pub static PKCS_ECDSA_P256_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[&OID_EC_PUBLIC_KEY, &OID_EC_SECP_256_R1],
+		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P256_SHA256_ASN1_SIGNING),
 		// ecdsa-with-SHA256 in RFC 5758
 		oid_components: &[1, 2, 840, 10045, 4, 3, 2],
@@ -163,6 +171,7 @@ pub mod algo {
 	/// ECDSA signing using the P-384 curves and SHA-384 hashing as per [RFC 5758](https://tools.ietf.org/html/rfc5758#section-3.2)
 	pub static PKCS_ECDSA_P384_SHA384: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[&OID_EC_PUBLIC_KEY, &OID_EC_SECP_384_R1],
+		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P384_SHA384_ASN1_SIGNING),
 		// ecdsa-with-SHA384 in RFC 5758
 		oid_components: &[1, 2, 840, 10045, 4, 3, 3],
@@ -175,6 +184,7 @@ pub mod algo {
 	pub static PKCS_ED25519: SignatureAlgorithm = SignatureAlgorithm {
 		// id-Ed25519 in RFC 8410
 		oids_sign_alg: &[&[1, 3, 101, 112]],
+		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EdDsa(&signature::ED25519),
 		// id-Ed25519 in RFC 8410
 		oid_components: &[1, 3, 101, 112],

--- a/rcgen/tests/botan.rs
+++ b/rcgen/tests/botan.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "x509-parser")]
+#![cfg(all(feature = "crypto", feature = "x509-parser"))]
 
 use rcgen::{BasicConstraints, Certificate, CertificateParams, DnType, IsCa};
 use rcgen::{

--- a/rcgen/tests/generic.rs
+++ b/rcgen/tests/generic.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "crypto")]
+
 mod util;
 
 #[cfg(feature = "pem")]

--- a/rcgen/tests/util.rs
+++ b/rcgen/tests/util.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "crypto")]
+
 use rcgen::{BasicConstraints, Certificate, CertificateParams, KeyPair};
 use rcgen::{
 	CertificateRevocationList, CrlDistributionPoint, CrlIssuingDistributionPoint, CrlScope,

--- a/rcgen/tests/webpki.rs
+++ b/rcgen/tests/webpki.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "crypto")]
+
 use pki_types::{CertificateDer, ServerName, SignatureVerificationAlgorithm, UnixTime};
 use rcgen::{
 	BasicConstraints, Certificate, CertificateParams, DnType, Error, IsCa, KeyPair, RemoteKeyPair,


### PR DESCRIPTION
This makes all of the crypto libraries optional. My use case requires simply generating the binary ASN.1 structures and all cryptography is handled externally with HSMs.

This change removes unnecessary code and build complexity (for example, I'm targeting WASM, and I need to take extra steps to build the dependencies I don't need).

Note to the maintainer: this is a clean (and ideally better) rework of a previous PR, #207. Because I deleted the older and messier branch, the previous PR couldn't be updated, so I closed it.