### PR TITLE
v0.12.1 preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aws-lc-rs",
  "botan",

--- a/rcgen/CHANGELOG.md
+++ b/rcgen/CHANGELOG.md
@@ -1,6 +1,15 @@
 
 # Changes
 
+## Release 0.12.1 - January 25th, 2024
+
+- RFC 5280 specifies that a serial number must not be larger than 20 octets in
+  length. Prior to this release an unintended interaction between rcgen and its
+  underlying DER encoding library could result in 21 octet serials. This has now
+  been fixed.
+- A regression that caused build errors when the optional `pem` feature was
+  omitted has been fixed.
+
 ## Release 0.12.0 - December 16, 2023
 
 - Rename `RcgenError` to `Error`. Contributed by [thomaseizinger](https://github.com/thomaseizinger).

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcgen"
-version = "0.12.0"
+version = "0.12.1"
 documentation = "https://docs.rs/rcgen"
 description.workspace = true
 repository.workspace = true


### PR DESCRIPTION
This PR targets a `rel-0.12` branch to prepare a 0.12.1 point release that includes two changes since 0.12.0:

* https://github.com/rustls/rcgen/pull/203 - ensure default serial generation fits 20 bytes
* https://github.com/rustls/rcgen/pull/204 - Allow building without the pem crate feature

Resolves https://github.com/rustls/rcgen/issues/218
