### PR TITLE
Use pki_types to improve the interoperability with the rustls ecosystem 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,7 @@ dependencies = [
  "rand",
  "rcgen",
  "ring",
+ "rustls-pki-types",
  "x509-parser",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 pem = "3.0.2"
+pki-types = { package = "rustls-pki-types", version = "1.3.0" }
 rand = "0.8"
 ring = "0.17"
 x509-parser = "0.16"

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -30,6 +30,7 @@ aws-lc-rs = { version = "1.6.0", optional = true }
 yasna = { version = "0.5.2", features = ["time", "std"] }
 ring = { workspace = true, optional = true }
 pem = { workspace = true, optional = true }
+pki-types = { workspace = true }
 time = { version = "0.3.6", default-features = false }
 x509-parser = { workspace = true, features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }
@@ -48,7 +49,8 @@ features = ["x509-parser"]
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
     "time::offset_date_time::OffsetDateTime",
-    "zeroize::Zeroize"
+    "zeroize::Zeroize",
+    "rustls_pki_types::*"
 ]
 
 [dev-dependencies]

--- a/rcgen/tests/webpki.rs
+++ b/rcgen/tests/webpki.rs
@@ -54,7 +54,7 @@ fn sign_msg_rsa(key_pair: &KeyPair, msg: &[u8], encoding: &'static dyn RsaEncodi
 }
 
 fn check_cert<'a, 'b>(
-	cert_der: &[u8],
+	cert_der: &CertificateDer<'_>,
 	cert: &'a Certificate,
 	cert_key: &'a KeyPair,
 	alg: &dyn SignatureVerificationAlgorithm,
@@ -68,18 +68,16 @@ fn check_cert<'a, 'b>(
 }
 
 fn check_cert_ca<'a, 'b>(
-	cert_der: &[u8],
+	cert_der: &CertificateDer<'_>,
 	cert_key: &'a KeyPair,
-	ca_der: &[u8],
+	ca_der: &CertificateDer<'_>,
 	cert_alg: &dyn SignatureVerificationAlgorithm,
 	ca_alg: &dyn SignatureVerificationAlgorithm,
 	sign_fn: impl FnOnce(&'a KeyPair, &'b [u8]) -> Vec<u8>,
 ) {
-	let ca_der = CertificateDer::from(ca_der);
-	let trust_anchor = anchor_from_trusted_cert(&ca_der).unwrap();
+	let trust_anchor = anchor_from_trusted_cert(ca_der).unwrap();
 	let trust_anchor_list = &[trust_anchor];
-	let cert_der = CertificateDer::from(cert_der);
-	let end_entity_cert = EndEntityCert::try_from(&cert_der).unwrap();
+	let end_entity_cert = EndEntityCert::try_from(cert_der).unwrap();
 
 	// Set time to Jan 10, 2004
 	let time = UnixTime::since_unix_epoch(StdDuration::from_secs(0x40_00_00_00));
@@ -592,11 +590,9 @@ fn test_webpki_crl_revoke() {
 	let ee = ee.signed_by(&ee_key, &issuer, &issuer_key).unwrap();
 
 	// Set up webpki's verification requirements.
-	let ca_der = CertificateDer::from(issuer.der());
-	let trust_anchor = anchor_from_trusted_cert(&ca_der).unwrap();
+	let trust_anchor = anchor_from_trusted_cert(issuer.der()).unwrap();
 	let trust_anchor_list = &[trust_anchor];
-	let ee_der = CertificateDer::from(ee.der());
-	let end_entity_cert = EndEntityCert::try_from(&ee_der).unwrap();
+	let end_entity_cert = EndEntityCert::try_from(ee.der()).unwrap();
 	let unix_time = 0x40_00_00_00;
 	let time = UnixTime::since_unix_epoch(StdDuration::from_secs(unix_time));
 

--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 rcgen = { path = "../rcgen", default-features = false, features = ["pem", "ring"] }
 bpaf = { version = "0.9.5", features = ["derive"] }
 pem = { workspace = true }
+pki-types = { workspace = true }
 ring = { workspace = true }
 rand = { workspace = true }
 anyhow = "1.0.75"

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -238,7 +238,7 @@ impl KeyPairAlgorithm {
 				let pkcs8_bytes =
 					Ed25519KeyPair::generate_pkcs8(&rng).or(Err(rcgen::Error::RingUnspecified))?;
 
-				rcgen::KeyPair::from_der_and_sign_algo(pkcs8_bytes.as_ref(), alg)
+				rcgen::KeyPair::from_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
 			KeyPairAlgorithm::EcdsaP256 => {
 				use ring::signature::EcdsaKeyPair;
@@ -249,7 +249,7 @@ impl KeyPairAlgorithm {
 				let pkcs8_bytes =
 					EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, &rng)
 						.or(Err(rcgen::Error::RingUnspecified))?;
-				rcgen::KeyPair::from_der_and_sign_algo(pkcs8_bytes.as_ref(), alg)
+				rcgen::KeyPair::from_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
 			KeyPairAlgorithm::EcdsaP384 => {
 				use ring::signature::EcdsaKeyPair;
@@ -261,7 +261,7 @@ impl KeyPairAlgorithm {
 					EcdsaKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, &rng)
 						.or(Err(rcgen::Error::RingUnspecified))?;
 
-				rcgen::KeyPair::from_der_and_sign_algo(pkcs8_bytes.as_ref(), alg)
+				rcgen::KeyPair::from_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
 		}
 	}


### PR DESCRIPTION
Use [`pki_types`] to improve the interoperability with the `rustls` ecosystem and make types pretty clear, as suggested by https://github.com/rustls/rcgen/pull/170#issuecomment-1849565550. 

To fully get rid of the `pem` dependency (by replacing it by `rustls_pemfile`), I think those further actions will be needed:
- add `CertificateSigningRequestDer` to  [`pki_types`]
- add a `Csr` variant to [rustls_pemfile::Item] which is a newtype of ` CertificateSigningRequestDer` 
- add some encoding capability to [rustls_pemfile](https://docs.rs/rustls-pemfile/latest/rustls_pemfile/index.html#), basically it would mean adding headers ("---- BEGIN ----") and handle well line ending.

Please let me know if I miss something and if you think this goes in the right direction.
I'm open to submit following PR for this.

[rustls_pemfile::Item]: https://docs.rs/rustls-pemfile/latest/rustls_pemfile/enum.Item.html
[`CryptoProvider`]: https://docs.rs/rustls/0.22.2/rustls/crypto/struct.CryptoProvider.html
[`pki_types`]: https://docs.rs/rustls-pki-types/latest/rustls_pki_types/index.html#