### PR TITLE
codecov: disable pull-request annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,3 @@
 comment: false
+github_checks:
+  annotations: false


### PR DESCRIPTION
By default Codecov leaves comments on diffs as ["annotations"](https://docs.codecov.com/docs/common-recipe-list#disable-github-check-run-annotations). These are separate from comments, which we disabled previously (https://github.com/rustls/rcgen/pull/187). This commit disables the annotations as well. Too much noise-to-signal right now.

Resolves https://github.com/rustls/rcgen/issues/186