### PR TITLE
ci: sync nightly for check-external-types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-10-10
+          toolchain: nightly-2024-02-07
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install --locked cargo-check-external-types
       - name: run cargo-check-external-types for rcgen/


### PR DESCRIPTION
Fixes [CI failures](https://github.com/rustls/rcgen/actions/runs/7920382172/job/21623293107) for the associated task.