### PR TITLE
proj: fix new clippy unused imports finding

### DIFF
--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "pem")]
 use pem::Pem;
-#[cfg(feature = "crypto")]
-use std::convert::TryFrom;
 use std::fmt;
 use yasna::DERWriter;
 

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -38,7 +38,6 @@ use pem::Pem;
 #[cfg(feature = "crypto")]
 use ring_like::digest;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fmt;
 use std::hash::Hash;
 use std::net::IpAddr;


### PR DESCRIPTION
The `std::convert::TryFrom` import is part of the rust 2021 edition prelude and so importing it explicitly is redundant. This results in a [clippy error](https://github.com/cpu/rcgen/actions/runs/7963608666/job/21739553339) for CI builds using nightly:

```
warning: the item `TryFrom` is imported redundantly
   --> rcgen/src/lib.rs:41:5
    |
41  | use std::convert::TryFrom;
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: /home/daniel/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:129:13
    |
129 |     pub use core::prelude::rust_2021::*;
    |             ------------------------ the item `TryFrom` is already defined here
    |
    = note: `#[warn(unused_imports)]` on by default
```