### PR TITLE
Remove get_() prefixes from method names

### DIFF
--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -76,7 +76,7 @@ impl CertificateRevocationList {
 		Ok(Self { params })
 	}
 	/// Returns the certificate revocation list (CRL) parameters.
-	pub fn get_params(&self) -> &CertificateRevocationListParams {
+	pub fn params(&self) -> &CertificateRevocationListParams {
 		&self.params
 	}
 	/// Serializes the certificate revocation list (CRL) in binary DER format, signed with

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -1680,12 +1680,12 @@ impl Certificate {
 		})
 	}
 	/// Returns the certificate parameters
-	pub fn get_params(&self) -> &CertificateParams {
+	pub fn params(&self) -> &CertificateParams {
 		&self.params
 	}
 	/// Calculates a subject key identifier for the certificate subject's public key.
 	/// This key identifier is used in the SubjectKeyIdentifier X.509v3 extension.
-	pub fn get_key_identifier(&self) -> Vec<u8> {
+	pub fn key_identifier(&self) -> Vec<u8> {
 		self.params
 			.key_identifier_method
 			.derive(&self.subject_public_key_info)
@@ -1857,7 +1857,7 @@ mod tests {
 
 	use std::panic::catch_unwind;
 
-	fn get_times() -> [OffsetDateTime; 2] {
+	fn times() -> [OffsetDateTime; 2] {
 		let dt_nanos = {
 			let date = Date::from_calendar_date(2020, Month::December, 3).unwrap();
 			let time = Time::from_hms_nano(0, 0, 1, 444).unwrap();
@@ -1874,7 +1874,7 @@ mod tests {
 
 	#[test]
 	fn test_dt_utc_strip_nanos() {
-		let times = get_times();
+		let times = times();
 
 		// No stripping - OffsetDateTime with nanos
 		let res = catch_unwind(|| UTCTime::from_datetime(times[0]));
@@ -1890,7 +1890,7 @@ mod tests {
 
 	#[test]
 	fn test_dt_to_generalized() {
-		let times = get_times();
+		let times = times();
 
 		for dt in times {
 			let _gt = dt_to_generalized(dt);
@@ -2237,7 +2237,7 @@ PITGdT9dgN88nHPCle0B1+OY+OZ5
 
 			let kp = KeyPair::from_pem(&ca_key).unwrap();
 			let ca_cert = Certificate::generate_self_signed(params, &kp).unwrap();
-			assert_eq!(&expected_ski, &ca_cert.get_key_identifier());
+			assert_eq!(&expected_ski, &ca_cert.key_identifier());
 
 			let (_remainder, x509) = x509_parser::parse_x509_certificate(ca_cert.der()).unwrap();
 			assert_eq!(

--- a/rcgen/tests/botan.rs
+++ b/rcgen/tests/botan.rs
@@ -230,7 +230,7 @@ fn test_botan_crl_parse() {
 		crl_number: rcgen::SerialNumber::from(1234),
 		issuing_distribution_point: None,
 		revoked_certs: vec![RevokedCertParams {
-			serial_number: ee.get_params().serial_number.clone().unwrap(),
+			serial_number: ee.params().serial_number.clone().unwrap(),
 			revocation_time: now,
 			reason_code: Some(RevocationReason::KeyCompromise),
 			invalidity_date: None,

--- a/rcgen/tests/generic.rs
+++ b/rcgen/tests/generic.rs
@@ -146,7 +146,7 @@ mod test_x509_parser_crl {
 	fn parse_crl() {
 		// Create a CRL with one revoked cert, and an issuer to sign the CRL.
 		let (crl, issuer, issuer_key) = util::test_crl();
-		let revoked_cert = crl.get_params().revoked_certs.first().unwrap();
+		let revoked_cert = crl.params().revoked_certs.first().unwrap();
 		let revoked_cert_serial = BigUint::from_bytes_be(revoked_cert.serial_number.as_ref());
 		let (_, x509_issuer) = X509Certificate::from_der(issuer.der()).unwrap();
 
@@ -162,7 +162,7 @@ mod test_x509_parser_crl {
 		assert_eq!(x509_crl.issuer(), x509_issuer.subject());
 		assert_eq!(
 			x509_crl.last_update().to_datetime().unix_timestamp(),
-			crl.get_params().this_update.unix_timestamp()
+			crl.params().this_update.unix_timestamp()
 		);
 		assert_eq!(
 			x509_crl
@@ -170,9 +170,9 @@ mod test_x509_parser_crl {
 				.unwrap()
 				.to_datetime()
 				.unix_timestamp(),
-			crl.get_params().next_update.unix_timestamp()
+			crl.params().next_update.unix_timestamp()
 		);
-		let crl_number = BigUint::from_bytes_be(crl.get_params().crl_number.as_ref());
+		let crl_number = BigUint::from_bytes_be(crl.params().crl_number.as_ref());
 		assert_eq!(x509_crl.crl_number().unwrap(), &crl_number);
 
 		// We should find the expected revoked certificate serial with the correct reason code.

--- a/rcgen/tests/openssl.rs
+++ b/rcgen/tests/openssl.rs
@@ -388,7 +388,7 @@ fn test_openssl_separate_ca_name_constraints() {
 fn test_openssl_crl_parse() {
 	// Create a CRL with one revoked cert, and an issuer to sign the CRL.
 	let (crl, issuer, issuer_key) = util::test_crl();
-	let revoked_cert = crl.get_params().revoked_certs.first().unwrap();
+	let revoked_cert = crl.params().revoked_certs.first().unwrap();
 	let revoked_cert_serial = &revoked_cert.serial_number;
 
 	// Serialize the CRL signed by the issuer in both PEM and DER.
@@ -404,10 +404,10 @@ fn test_openssl_crl_parse() {
 	// The properties of the CRL should match expected.
 	let openssl_issuer = X509::from_der(issuer.der()).unwrap();
 	let expected_last_update =
-		Asn1Time::from_unix(crl.get_params().this_update.unix_timestamp()).unwrap();
+		Asn1Time::from_unix(crl.params().this_update.unix_timestamp()).unwrap();
 	assert!(openssl_crl.last_update().eq(&expected_last_update));
 	let expected_next_update =
-		Asn1Time::from_unix(crl.get_params().next_update.unix_timestamp()).unwrap();
+		Asn1Time::from_unix(crl.params().next_update.unix_timestamp()).unwrap();
 	assert!(openssl_crl.next_update().unwrap().eq(&expected_next_update));
 	assert!(matches!(
 		openssl_crl

--- a/rcgen/tests/webpki.rs
+++ b/rcgen/tests/webpki.rs
@@ -536,7 +536,7 @@ fn test_webpki_serial_number() {
 fn test_webpki_crl_parse() {
 	// Create a CRL with one revoked cert, and an issuer to sign the CRL.
 	let (crl, issuer, issuer_key) = util::test_crl();
-	let revoked_cert = crl.get_params().revoked_certs.first().unwrap();
+	let revoked_cert = crl.params().revoked_certs.first().unwrap();
 
 	// Serialize the CRL signed by the issuer to DER.
 	let der = crl.serialize_der_with_signer(&issuer, &issuer_key).unwrap();
@@ -619,7 +619,7 @@ fn test_webpki_crl_revoke() {
 		crl_number: rcgen::SerialNumber::from(1234),
 		issuing_distribution_point: None,
 		revoked_certs: vec![RevokedCertParams {
-			serial_number: ee.get_params().serial_number.clone().unwrap(),
+			serial_number: ee.params().serial_number.clone().unwrap(),
 			revocation_time: now,
 			reason_code: Some(RevocationReason::KeyCompromise),
 			invalidity_date: None,


### PR DESCRIPTION
Aligning with the [API guidelines](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter).