### PR TITLE
FIPS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
       run: cargo test --verbose --features x509-parser --all-targets
     - name: Run the tests with aws_lc_rs backend enabled
       run: cargo test --verbose --no-default-features --features aws_lc_rs,pem --all-targets
+    - name: Run the tests with FIPS aws_lc_rs module
+      run: cargo test --verbose --no-default-features --features fips,pem --all-targets
     - name: Run the tests with no features enabled
       run: cargo test --verbose --no-default-features --all-targets
 
@@ -179,6 +181,8 @@ jobs:
       run: cargo test --verbose --features x509-parser --all-targets
     - name: Run the tests with aws_lc_rs backend enabled
       run: cargo test --verbose --no-default-features --features aws_lc_rs,pem --all-targets
+    - name: Run the tests with FIPS aws_lc_rs module
+      run: cargo test --verbose --no-default-features --features fips,pem --all-targets
 
   # Build rustls-cert-gen as a standalone package, see this PR for why it's needed:
   # https://github.com/rustls/rcgen/pull/206#pullrequestreview-1816197358

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,11 +84,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33c1a4881f0f751f1fc32d101755393b50e2dcb9857857974d880e2fa5d4749"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33e4a55b03f8780ba55041bc7be91a2a8ec8c03517b0379d2d6c96d2c30d95"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "mirai-annotations",
  "paste",

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -39,6 +39,7 @@ default = ["crypto", "pem", "ring"]
 crypto = []
 aws_lc_rs = ["crypto", "dep:aws-lc-rs"]
 ring = ["crypto", "dep:ring"]
+fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
 
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Following the same direction of `rustls`, from the latest version ([0.23.0](https://github.com/rustls/rustls/releases/tag/v%2F0.23.0)):
> Default cryptography provider changed to [aws-lc-rs](https://crates.io/crates/aws-lc-rs).
> [...]
> Support for FIPS validated mode with [aws-lc-rs](https://crates.io/crates/aws-lc-rs)

This PR is composed by 2 commits:
* Adding `fips` feature to enable `aws_lc_rs/fips`
* Changing default crypto backend from `ring` to `aws_lc_rs`
