### PR TITLE
Support more private key formats when using aws_lc_rs feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 aws-lc-rs = "1.6.0"
 pem = "3.0.2"
-pki-types = { package = "rustls-pki-types", version = "1.3.0" }
+pki-types = { package = "rustls-pki-types", version = "1.4.1" }
 rand = "0.8"
 ring = "0.17"
 x509-parser = "0.16"

--- a/rcgen/src/ring_like.rs
+++ b/rcgen/src/ring_like.rs
@@ -25,6 +25,14 @@ pub(crate) fn ecdsa_from_pkcs8(
 	}
 }
 
+#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+pub(crate) fn ecdsa_from_private_key_der(
+	alg: &'static signature::EcdsaSigningAlgorithm,
+	key: &[u8],
+) -> Result<signature::EcdsaKeyPair, Error> {
+	Ok(signature::EcdsaKeyPair::from_private_key_der(alg, key)._err()?)
+}
+
 #[cfg(feature = "crypto")]
 pub(crate) fn rsa_key_pair_public_modulus_len(kp: &signature::RsaKeyPair) -> usize {
 	#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]

--- a/rcgen/tests/openssl.rs
+++ b/rcgen/tests/openssl.rs
@@ -494,3 +494,33 @@ fn test_openssl_crl_dps_parse() {
 		]
 	);
 }
+
+#[test]
+#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+fn test_openssl_pkcs1_and_sec1_keys() {
+	use openssl::ec::{EcGroup, EcKey};
+	use openssl::nid::Nid;
+	use openssl::pkey::PKey;
+	use openssl::rsa::Rsa;
+	use pki_types::PrivateKeyDer;
+
+	let rsa = Rsa::generate(2048).unwrap();
+	let rsa = PKey::from_rsa(rsa).unwrap();
+
+	let pkcs1_rsa_key_der = PrivateKeyDer::try_from(rsa.private_key_to_der().unwrap()).unwrap();
+	KeyPair::try_from(&pkcs1_rsa_key_der).unwrap();
+
+	let pkcs8_rsa_key_der = PrivateKeyDer::try_from(rsa.private_key_to_pkcs8().unwrap()).unwrap();
+	KeyPair::try_from(&pkcs8_rsa_key_der).unwrap();
+
+	let group = EcGroup::from_curve_name(Nid::SECP521R1).unwrap();
+	let ec_key = EcKey::generate(&group).unwrap();
+
+	let ec_key = PKey::from_ec_key(ec_key).unwrap();
+
+	let sec1_ec_key_der = PrivateKeyDer::try_from(ec_key.private_key_to_der().unwrap()).unwrap();
+	KeyPair::try_from(&sec1_ec_key_der).unwrap();
+
+	let pkcs8_ec_key_der = PrivateKeyDer::try_from(ec_key.private_key_to_pkcs8().unwrap()).unwrap();
+	KeyPair::try_from(&pkcs8_ec_key_der).unwrap();
+}


### PR DESCRIPTION
I hope this change is okay. I am not sure if I need to add tests for this? Also should I rename the function in ring-like?