### PR TITLE
Unbreak doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: cargo doc (all features)
         run: cargo doc --all-features --document-private-items
         env:
-          RUSTDOCFLAGS: ${{ matrix.rust_channel == 'nightly' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
+          RUSTDOCFLAGS: ${{ matrix.toolchain == 'nightly' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
 
   check-external-types:
     name: Validate external types appearing in public API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,15 +133,15 @@ jobs:
     - name: Run cargo check
       run: cargo check --all-targets
     - name: Run the tests
-      run: cargo test --all-targets
+      run: cargo test
     - name: Run the tests with x509-parser enabled
-      run: cargo test --verbose --features x509-parser --all-targets
+      run: cargo test --verbose --features x509-parser
     - name: Run the tests with aws_lc_rs backend enabled
-      run: cargo test --verbose --no-default-features --features aws_lc_rs,pem --all-targets
+      run: cargo test --verbose --no-default-features --features aws_lc_rs,pem
     - name: Run the tests with FIPS aws_lc_rs module
-      run: cargo test --verbose --no-default-features --features fips,pem --all-targets
+      run: cargo test --verbose --no-default-features --features fips,pem
     - name: Run the tests with no features enabled
-      run: cargo test --verbose --no-default-features --all-targets
+      run: cargo test --verbose --no-default-features
 
   build:
     strategy:
@@ -176,13 +176,13 @@ jobs:
     - name: Run cargo check
       run: cargo check --all-targets
     - name: Run the tests
-      run: cargo test --all-targets
+      run: cargo test
     - name: Run the tests with x509-parser enabled
-      run: cargo test --verbose --features x509-parser --all-targets
+      run: cargo test --verbose --features x509-parser
     - name: Run the tests with aws_lc_rs backend enabled
-      run: cargo test --verbose --no-default-features --features aws_lc_rs,pem --all-targets
+      run: cargo test --verbose --no-default-features --features aws_lc_rs,pem
     - name: Run the tests with FIPS aws_lc_rs module
-      run: cargo test --verbose --no-default-features --features fips,pem --all-targets
+      run: cargo test --verbose --no-default-features --features fips,pem
 
   # Build rustls-cert-gen as a standalone package, see this PR for why it's needed:
   # https://github.com/rustls/rcgen/pull/206#pullrequestreview-1816197358

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -40,7 +40,7 @@ use crate::{
 /// let remote_key_pair = MyKeyPair { public_key: vec![] };
 /// #[cfg(not(feature = "crypto"))]
 /// let key_pair = KeyPair::from_remote(Box::new(remote_key_pair)).unwrap();
-/// let issuer = Certificate::generate_self_signed(issuer_params, &key_pair).unwrap();
+/// let issuer = issuer_params.self_signed(&key_pair).unwrap();
 /// // Describe a revoked certificate.
 /// let revoked_cert = RevokedCertParams{
 ///   serial_number: SerialNumber::from(9999),


### PR DESCRIPTION
#233 regressed a doctest for CRL signing. It turns out CI was using `test --all-targets` which is documented as omitting doctests:

```
djc-2021 ci-doctests rcgen $ cargo test -h
Execute all unit and integration tests and build examples of a local package

[..]

Target Selection:
      [..]
      --all-targets       Test all targets (does not include doctests)
```