### PR TITLE
lib: export key_pair::RsaKeySize

### DIFF
--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -470,8 +470,11 @@ impl TryFrom<&PrivatePkcs8KeyDer<'_>> for KeyPair {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum RsaKeySize {
+	/// 2048 bits
 	_2048,
+	/// 3072 bits
 	_3072,
+	/// 4096 bits
 	_4096,
 }
 

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -59,6 +59,8 @@ pub use crl::{
 pub use csr::{CertificateSigningRequestParams, PublicKey};
 pub use error::{Error, InvalidAsn1String};
 use key_pair::PublicKeyData;
+#[cfg(all(feature = "crypto", feature = "aws_lc_rs", not(feature = "ring")))]
+pub use key_pair::RsaKeySize;
 pub use key_pair::{KeyPair, RemoteKeyPair};
 #[cfg(feature = "crypto")]
 use ring_like::digest;


### PR DESCRIPTION
The new `KeyPair::generate_rsa_for` fn from https://github.com/rustls/rcgen/pull/230 is only usable outside the crate if the `key_pair::RsaKeySize` type is exported from `lib.rs` since `key_pair` is a private module.