### PR TITLE
Add rsa keypair generation using the rsa crate.

### DIFF
--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -26,14 +26,17 @@ aws-lc-rs = { version = "1.0.0", optional = true }
 yasna = { version = "0.5.2", features = ["time", "std"] }
 ring = { version = "0.17", optional = true }
 pem = { workspace = true, optional = true }
+rand = { version = "0.8.5", optional = true }
+rsa = { version = "0.9.6", optional = true }
 time = { version = "0.3.6", default-features = false }
 x509-parser = { version = "0.15", features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }
 
 [features]
-default = ["pem", "ring"]
+default = ["pem", "ring", "rsa"]
 aws_lc_rs = ["dep:aws-lc-rs"]
 ring = ["dep:ring"]
+rsa = ["dep:rsa", "dep:rand"]
 
 [package.metadata.docs.rs]
 features = ["x509-parser"]

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -204,9 +204,21 @@ impl KeyPair {
 					serialized_der: key_pair_serialized,
 				})
 			},
+			#[cfg(feature = "rsa")]
+			SignAlgo::Rsa() => {
+				use rsa::pkcs8::EncodePrivateKey;
+				let bits = 4096;
+				let mut rng = rand::thread_rng();
+				let priv_key = rsa::RsaPrivateKey::new(&mut rng, bits).map_err(|_| Error::CouldNotParseKeyPair)?;
+				let pkcs8 = priv_key.to_pkcs8_der().map_err(|_| Error::CouldNotParseKeyPair)?.to_bytes();
+				Ok(
+					KeyPair::from_der(&pkcs8)?
+				)
+			}
 			// Ring doesn't have RSA key generation yet:
 			// https://github.com/briansmith/ring/issues/219
 			// https://github.com/briansmith/ring/pull/733
+			#[cfg(not(feature = "rsa"))]
 			SignAlgo::Rsa() => Err(Error::KeyGenerationUnavailable),
 		}
 	}


### PR DESCRIPTION
This pull request add capability of generating a 4096 bit keypair using the rsa crate. I wasn't sure how to get the number of bits for the keypair so I assumed 4096.