### PR TITLE
Fix unused import warning

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -1143,6 +1143,7 @@ pub enum BasicConstraints {
 
 #[cfg(test)]
 mod tests {
+	#[cfg(feature = "pem")]
 	use super::*;
 
 	#[cfg(crypto)]


### PR DESCRIPTION
This PR is remove a warning as requested on [241](https://github.com/rustls/rcgen/pull/241#issuecomment-2006224451).

Alternatively I could use `use super::super::*` in relevant tests and get rid of the conditional compilation. I feel that way could be easier to maintain.