### PR TITLE
key_pair: emphasize PKCS8 input requirement in constructor fn names

### DIFF
--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -189,9 +189,9 @@ impl KeyPair {
 	/// The key must be a DER-encoded plaintext private key; as specified in PKCS #8/RFC 5958;
 	///
 	/// Appears as "PRIVATE KEY" in PEM files
-	/// Same as [from_pem_and_sign_algo](Self::from_pem_and_sign_algo).
+	/// Same as [from_pkcs8_pem_and_sign_algo](Self::from_pkcs8_pem_and_sign_algo).
 	#[cfg(all(feature = "pem", feature = "crypto"))]
-	pub fn from_pem_and_sign_algo(
+	pub fn from_pkcs8_pem_and_sign_algo(
 		pem_str: &str,
 		alg: &'static SignatureAlgorithm,
 	) -> Result<Self, Error> {

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -197,7 +197,7 @@ impl KeyPair {
 	) -> Result<Self, Error> {
 		let private_key = pem::parse(pem_str)._err()?;
 		let private_key_der: &[_] = private_key.contents();
-		Self::from_der_and_sign_algo(&PrivatePkcs8KeyDer::from(private_key_der), alg)
+		Self::from_pkcs8_der_and_sign_algo(&PrivatePkcs8KeyDer::from(private_key_der), alg)
 	}
 
 	/// Obtains the key pair from a DER formatted key using the specified [`SignatureAlgorithm`]
@@ -215,7 +215,7 @@ impl KeyPair {
 	/// [`rustls_pemfile::private_key()`]: https://docs.rs/rustls-pemfile/latest/rustls_pemfile/fn.private_key.html
 	/// [`PrivateKeyDer`]: https://docs.rs/rustls-pki-types/latest/rustls_pki_types/enum.PrivateKeyDer.html
 	#[cfg(feature = "crypto")]
-	pub fn from_der_and_sign_algo(
+	pub fn from_pkcs8_der_and_sign_algo(
 		pkcs8: &PrivatePkcs8KeyDer<'_>,
 		alg: &'static SignatureAlgorithm,
 	) -> Result<Self, Error> {

--- a/rcgen/tests/openssl.rs
+++ b/rcgen/tests/openssl.rs
@@ -280,7 +280,8 @@ fn test_openssl_rsa_combinations_given() {
 	];
 	for (i, alg) in alg_list.iter().enumerate() {
 		let (params, _) = util::default_params();
-		let key_pair = KeyPair::from_pem_and_sign_algo(util::RSA_TEST_KEY_PAIR_PEM, alg).unwrap();
+		let key_pair =
+			KeyPair::from_pkcs8_pem_and_sign_algo(util::RSA_TEST_KEY_PAIR_PEM, alg).unwrap();
 		let cert = params.self_signed(&key_pair).unwrap();
 
 		// Now verify the certificate.

--- a/rcgen/tests/webpki.rs
+++ b/rcgen/tests/webpki.rs
@@ -249,7 +249,7 @@ fn test_webpki_rsa_combinations_given() {
 	for c in configs {
 		let (params, _) = util::default_params();
 		let key_pair =
-			rcgen::KeyPair::from_pem_and_sign_algo(util::RSA_TEST_KEY_PAIR_PEM, c.0).unwrap();
+			rcgen::KeyPair::from_pkcs8_pem_and_sign_algo(util::RSA_TEST_KEY_PAIR_PEM, c.0).unwrap();
 		let cert = params.self_signed(&key_pair).unwrap();
 
 		// Now verify the certificate.

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -239,7 +239,7 @@ impl KeyPairAlgorithm {
 				let pkcs8_bytes =
 					Ed25519KeyPair::generate_pkcs8(&rng).or(Err(rcgen::Error::RingUnspecified))?;
 
-				rcgen::KeyPair::from_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
+				rcgen::KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
 			KeyPairAlgorithm::EcdsaP256 => {
 				use ring::signature::EcdsaKeyPair;
@@ -250,7 +250,7 @@ impl KeyPairAlgorithm {
 				let pkcs8_bytes =
 					EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, &rng)
 						.or(Err(rcgen::Error::RingUnspecified))?;
-				rcgen::KeyPair::from_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
+				rcgen::KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
 			KeyPairAlgorithm::EcdsaP384 => {
 				use ring::signature::EcdsaKeyPair;
@@ -262,7 +262,7 @@ impl KeyPairAlgorithm {
 					EcdsaKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, &rng)
 						.or(Err(rcgen::Error::RingUnspecified))?;
 
-				rcgen::KeyPair::from_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
+				rcgen::KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
 		}
 	}


### PR DESCRIPTION
This branch pulls out the [suggested rename](https://github.com/rustls/rcgen/pull/242#issuecomment-2006944259) from https://github.com/rustls/rcgen/pull/242 in order to unblock release planning (https://github.com/rustls/rcgen/issues/236) while the more generic key pair constructor is worked out.