### PR TITLE
Add ability to get a PublicKey from a KeyPair.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aws-lc-rs",
  "botan",

--- a/rcgen/CHANGELOG.md
+++ b/rcgen/CHANGELOG.md
@@ -1,6 +1,15 @@
 
 # Changes
 
+## Release 0.12.1 - January 25th, 2024
+
+- RFC 5280 specifies that a serial number must not be larger than 20 octets in
+  length. Prior to this release an unintended interaction between rcgen and its
+  underlying DER encoding library could result in 21 octet serials. This has now
+  been fixed.
+- A regression that caused build errors when the optional `pem` feature was
+  omitted has been fixed.
+
 ## Release 0.12.0 - December 16, 2023
 
 - Rename `RcgenError` to `Error`. Contributed by [thomaseizinger](https://github.com/thomaseizinger).

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcgen"
-version = "0.12.0"
+version = "0.12.1"
 documentation = "https://docs.rs/rcgen"
 description.workspace = true
 repository.workspace = true

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -9,8 +9,8 @@ use crate::{Certificate, CertificateParams, Error, PublicKeyData, SignatureAlgor
 /// A public key, extracted from a CSR
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct PublicKey {
-	raw: Vec<u8>,
-	alg: &'static SignatureAlgorithm,
+	pub(crate) raw: Vec<u8>,
+	pub(crate) alg: &'static SignatureAlgorithm,
 }
 
 impl PublicKeyData for PublicKey {

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -211,6 +211,11 @@ impl KeyPair {
 		}
 	}
 
+	/// Get the public key of this key pair as a [`PublicKey`]
+	pub fn public_key(&self) -> crate::PublicKey {
+		crate::PublicKey { raw: self.raw_bytes().to_vec(), alg: self.alg, }
+	}
+
 	/// Get the raw public key of this key pair
 	///
 	/// The key is in raw format, as how [`ring::signature::KeyPair::public_key`]

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -211,9 +211,12 @@ impl KeyPair {
 		}
 	}
 
-	/// Get the public key of this key pair as a [`PublicKey`]
+	/// Get the public key of this key pair as a [`crate::PublicKey`]
 	pub fn public_key(&self) -> crate::PublicKey {
-		crate::PublicKey { raw: self.raw_bytes().to_vec(), alg: self.alg, }
+		crate::PublicKey {
+			raw: self.raw_bytes().to_vec(),
+			alg: self.alg,
+		}
 	}
 
 	/// Get the raw public key of this key pair


### PR DESCRIPTION
This patch adds the ability to get a PublicKey struct directly from a KeyPair. I used this method to generate a csr and sign it with another certificate.