### PR TITLE
Minor API tweaks

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -57,6 +57,7 @@ impl Certificate {
 /// Parameters used for certificate generation
 #[allow(missing_docs)]
 #[non_exhaustive]
+#[derive(Clone)]
 pub struct CertificateParams {
 	pub not_before: OffsetDateTime,
 	pub not_after: OffsetDateTime,

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -54,6 +54,12 @@ impl Certificate {
 	}
 }
 
+impl From<Certificate> for CertificateDer<'static> {
+	fn from(cert: Certificate) -> Self {
+		cert.der
+	}
+}
+
 /// Parameters used for certificate generation
 #[allow(missing_docs)]
 #[non_exhaustive]

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -89,6 +89,12 @@ impl CertificateRevocationList {
 	}
 }
 
+impl From<CertificateRevocationList> for CertificateRevocationListDer<'static> {
+	fn from(crl: CertificateRevocationList) -> Self {
+		crl.der
+	}
+}
+
 /// A certificate revocation list (CRL) distribution point, to be included in a certificate's
 /// [distribution points extension](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.13) or
 /// a CRL's [issuing distribution point extension](https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.5)

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -48,6 +48,12 @@ impl CertificateSigningRequest {
 	}
 }
 
+impl From<CertificateSigningRequest> for CertificateSigningRequestDer<'static> {
+	fn from(csr: CertificateSigningRequest) -> Self {
+		csr.der
+	}
+}
+
 /// Parameters for a certificate signing request
 pub struct CertificateSigningRequestParams {
 	/// Parameters for the certificate to be signed.


### PR DESCRIPTION
These are non-semver-breaking so they don't need to block the release, but I think they are a natural addition to API changes we've already made (moving `KeyPair` out of `CertificateParams` and storing `*Der` types internally).