### PR TITLE
Set library version for CLI crate

### DIFF
--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -13,7 +13,7 @@ ring = ["dep:ring", "rcgen/ring"]
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
 
 [dependencies]
-rcgen = { path = "../rcgen", default-features = false, features = ["pem"] }
+rcgen = { version = "0.13", path = "../rcgen", default-features = false, features = ["pem"] }
 bpaf = { version = "0.9.5", features = ["derive"] }
 pem = { workspace = true }
 pki-types = { workspace = true }


### PR DESCRIPTION
Encountered this error while trying to `cargo publish` rustls-cert-gen:

```
djc-2021 main rustls-cert-gen $ cargo publish
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `rcgen` does not specify a version
Note: The published dependency will use the version from crates.io,
the `path` specification will be removed from the dependency declaration.
```