### PR TITLE
cli: add more Cargo metadata

### DIFF
--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -2,6 +2,9 @@
 name = "rustls-cert-gen"
 version = "0.1.0"
 description = "Rust X.509 certificate generator CLI"
+documentation = "https://docs.rs/rustls-cert-gen"
+homepage = "https://github.com/rustls/rcgen/tree/main/rustls-cert-gen"
+repository = "https://github.com/rustls/rcgen"
 license.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
```
djc-2021 main rustls-cert-gen $ cargo publish
    Updating crates.io index
warning: manifest has no documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
```

(I aborted before it completed publishing.)