### PR TITLE
Clarify internal data dependencies for signing APIs

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -156,6 +156,7 @@ impl CertificateParams {
 		let issuer = Issuer {
 			distinguished_name: &issuer.params.distinguished_name,
 			key_identifier_method: &issuer.params.key_identifier_method,
+			key_usages: &issuer.params.key_usages,
 			key_pair: issuer_key,
 		};
 
@@ -176,6 +177,7 @@ impl CertificateParams {
 		let issuer = Issuer {
 			distinguished_name: &self.distinguished_name,
 			key_identifier_method: &self.key_identifier_method,
+			key_usages: &self.key_usages,
 			key_pair,
 		};
 

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -154,6 +154,7 @@ impl CertificateSigningRequestParams {
 		let issuer = Issuer {
 			distinguished_name: &issuer.params.distinguished_name,
 			key_identifier_method: &issuer.params.key_identifier_method,
+			key_usages: &issuer.params.key_usages,
 			key_pair: issuer_key,
 		};
 

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -130,6 +130,12 @@ pub fn generate_simple_self_signed(
 	Ok(CertifiedKey { cert, key_pair })
 }
 
+struct Issuer<'a> {
+	distinguished_name: &'a DistinguishedName,
+	key_identifier_method: &'a KeyIdMethod,
+	key_pair: &'a KeyPair,
+}
+
 // https://tools.ietf.org/html/rfc5280#section-4.1.1
 
 // Example certs usable as reference:

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -133,6 +133,7 @@ pub fn generate_simple_self_signed(
 struct Issuer<'a> {
 	distinguished_name: &'a DistinguishedName,
 	key_identifier_method: &'a KeyIdMethod,
+	key_usages: &'a [KeyUsagePurpose],
 	key_pair: &'a KeyPair,
 }
 


### PR DESCRIPTION
Without changing the public API, prepare for splitting out a type that is capable of signing.