### PR TITLE
error: feature-gate ExternalError

### DIFF
--- a/rcgen/src/error.rs
+++ b/rcgen/src/error.rs
@@ -132,6 +132,7 @@ impl fmt::Display for InvalidAsn1String {
 ///
 /// We use this trait to avoid leaking external error types into the public API
 /// through a `From<x> for Error` implementation.
+#[cfg(any(feature = "crypto", feature = "pem"))]
 pub(crate) trait ExternalError<T>: Sized {
 	fn _err(self) -> Result<T, Error>;
 }


### PR DESCRIPTION
This trait is only used when the `crypto` or `pem` features are enabled, producing a warning with Rust 1.80 clippy (as seen in [CI failures](https://github.com/rustls/rcgen/actions/runs/8928448138)) when building with `--no-default-features`. This commit config-gates its definition to avoid that warning.