### PR TITLE
fix missing export of `KeyPairAlgorithm`

### DIFF
--- a/rustls-cert-gen/src/lib.rs
+++ b/rustls-cert-gen/src/lib.rs
@@ -5,4 +5,5 @@
 //! whatever purpose you may need a TLS certificate-chain.
 
 mod cert;
-pub use cert::{Ca, CaBuilder, CertificateBuilder, EndEntity, EndEntityBuilder};
+pub use cert::{Ca, CaBuilder, CertificateBuilder, EndEntity, EndEntityBuilder, KeyPairAlgorithm};
+pub use rcgen;


### PR DESCRIPTION
This was preventing me from using `rustls-cert-gen` as a library.
Also re-export `rcgen` crate to access shared types.