### PR TITLE
`Issuer` API

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -29,10 +29,21 @@ pub struct Certificate {
 }
 
 impl Certificate {
+	/// TODO
+	pub fn from_der(der: CertificateDer<'static>, keypair: KeyPair) -> Result<Self, Error> {
+		let params = CertificateParams::from_ca_cert_der(&der)?;
+		Ok(Self {
+			params,
+			subject_public_key_info: keypair.public_key_der(),
+			der,
+		})
+	}
+
 	/// Returns the certificate parameters
 	pub fn params(&self) -> &CertificateParams {
 		&self.params
 	}
+
 	/// Calculates a subject key identifier for the certificate subject's public key.
 	/// This key identifier is used in the SubjectKeyIdentifier X.509v3 extension.
 	pub fn key_identifier(&self) -> Vec<u8> {
@@ -40,6 +51,7 @@ impl Certificate {
 			.key_identifier_method
 			.derive(&self.subject_public_key_info)
 	}
+
 	/// Get the certificate in DER encoded format.
 	///
 	/// [`CertificateDer`] implements `Deref<Target = [u8]>` and `AsRef<[u8]>`, so you can easily
@@ -47,6 +59,7 @@ impl Certificate {
 	pub fn der(&self) -> &CertificateDer<'static> {
 		&self.der
 	}
+
 	/// Get the certificate in PEM encoded format.
 	#[cfg(feature = "pem")]
 	pub fn pem(&self) -> String {

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -29,16 +29,6 @@ pub struct Certificate {
 }
 
 impl Certificate {
-	/// TODO
-	pub fn from_der(der: CertificateDer<'static>, keypair: KeyPair) -> Result<Self, Error> {
-		let params = CertificateParams::from_ca_cert_der(&der)?;
-		Ok(Self {
-			params,
-			subject_public_key_info: keypair.public_key_der(),
-			der,
-		})
-	}
-
 	/// Returns the certificate parameters
 	pub fn params(&self) -> &CertificateParams {
 		&self.params

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -186,21 +186,10 @@ impl CertificateRevocationListParams {
 	/// Serializes the certificate revocation list (CRL).
 	///
 	/// Including a signature from the issuing certificate authority's key.
-	pub fn signed_by(
-		self,
-		issuer: &Certificate,
-		issuer_key: &KeyPair,
-	) -> Result<CertificateRevocationList, Error> {
+	pub fn signed_by(self, issuer: &Issuer) -> Result<CertificateRevocationList, Error> {
 		if self.next_update.le(&self.this_update) {
 			return Err(Error::InvalidCrlNextUpdate);
 		}
-
-		let issuer = Issuer {
-			distinguished_name: &issuer.params.distinguished_name,
-			key_identifier_method: &issuer.params.key_identifier_method,
-			key_usages: &issuer.params.key_usages,
-			key_pair: issuer_key,
-		};
 
 		if !issuer.key_usages.is_empty() && !issuer.key_usages.contains(&KeyUsagePurpose::CrlSign) {
 			return Err(Error::IssuerNotCrlSigner);
@@ -212,7 +201,7 @@ impl CertificateRevocationListParams {
 		})
 	}
 
-	fn serialize_der(&self, issuer: Issuer) -> Result<Vec<u8>, Error> {
+	fn serialize_der(&self, issuer: &Issuer) -> Result<Vec<u8>, Error> {
 		issuer.key_pair.sign_der(|writer| {
 			// Write CRL version.
 			// RFC 5280 §5.1.2.1:

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -184,21 +184,10 @@ impl CertificateSigningRequestParams {
 	///
 	/// The returned [`Certificate`] may be serialized using [`Certificate::der`] and
 	/// [`Certificate::pem`].
-	pub fn signed_by(
-		self,
-		issuer: &Certificate,
-		issuer_key: &KeyPair,
-	) -> Result<Certificate, Error> {
-		let issuer = Issuer {
-			distinguished_name: &issuer.params.distinguished_name,
-			key_identifier_method: &issuer.params.key_identifier_method,
-			key_usages: &issuer.params.key_usages,
-			key_pair: issuer_key,
-		};
-
+	pub fn signed_by(self, issuer: &Issuer) -> Result<Certificate, Error> {
 		let der = self
 			.params
-			.serialize_der_with_signer(&self.public_key, issuer)?;
+			.serialize_der_with_signer(&self.public_key, &issuer)?;
 		let subject_public_key_info = yasna::construct_der(|writer| {
 			self.public_key.serialize_public_key_der(writer);
 		});

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -46,8 +46,13 @@ impl Issuer {
 	}
 
 	/// TODO
-	pub fn pem(&self) -> String {
-		todo!();
+	pub fn cert_pem(&self) -> String {
+		todo!("required for `rustls-cert-gen`");
+	}
+
+	/// TODO
+	pub fn key_pem(&self) -> String {
+		todo!("seems a fitting complement to `Self::cert_pem`");
 	}
 
 	/// TODO

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -1,0 +1,11 @@
+use crate::{DistinguishedName, KeyIdMethod, KeyPair, KeyUsagePurpose};
+
+/// TODO
+pub struct Issuer<'a> {
+	pub(crate) distinguished_name: &'a DistinguishedName,
+	pub(crate) key_identifier_method: &'a KeyIdMethod,
+	pub(crate) key_usages: &'a [KeyUsagePurpose],
+	pub(crate) key_pair: &'a KeyPair,
+}
+
+impl<'a> Issuer<'a> {}

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -1,11 +1,57 @@
-use crate::{DistinguishedName, KeyIdMethod, KeyPair, KeyUsagePurpose};
+use pki_types::CertificateDer;
+
+use crate::{
+	Certificate, CertificateParams, DistinguishedName, Error, KeyIdMethod, KeyPair, KeyUsagePurpose,
+};
 
 /// TODO
-pub struct Issuer<'a> {
-	pub(crate) distinguished_name: &'a DistinguishedName,
-	pub(crate) key_identifier_method: &'a KeyIdMethod,
-	pub(crate) key_usages: &'a [KeyUsagePurpose],
-	pub(crate) key_pair: &'a KeyPair,
+pub struct Issuer {
+	pub(crate) distinguished_name: DistinguishedName,
+	pub(crate) key_identifier_method: KeyIdMethod,
+	pub(crate) key_usages: Vec<KeyUsagePurpose>,
+	pub(crate) key_pair: KeyPair,
 }
 
-impl<'a> Issuer<'a> {}
+impl Issuer {
+	/// TODO
+	pub fn new(ca_cert: CertificateDer, key_pair: KeyPair) -> Result<Self, Error> {
+		let params = CertificateParams::from_ca_cert_der(&ca_cert)?;
+		Ok(Self {
+			distinguished_name: params.distinguished_name,
+			key_identifier_method: params.key_identifier_method,
+			key_usages: params.key_usages,
+			key_pair,
+		})
+	}
+
+	/// TODO
+	pub fn from_params(params: CertificateParams, key_pair: KeyPair) -> Self {
+		Self {
+			distinguished_name: params.distinguished_name,
+			key_identifier_method: params.key_identifier_method,
+			key_usages: params.key_usages,
+			key_pair,
+		}
+	}
+
+	/// TODO
+	pub fn certificate(&self) -> Certificate {
+		// let params = CertificateParams::from_ca_cert_der(&der)?;
+		// Ok(Certificate {
+		// 	params,
+		// 	subject_public_key_info: keypair.public_key_der(),
+		// 	der,
+		// })
+		todo!();
+	}
+
+	/// TODO
+	pub fn pem(&self) -> String {
+		todo!();
+	}
+
+	/// TODO
+	pub fn key_pair(&self) -> &KeyPair {
+		&self.key_pair
+	}
+}

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -58,6 +58,7 @@ pub use crl::{
 };
 pub use csr::{CertificateSigningRequest, CertificateSigningRequestParams, PublicKey};
 pub use error::{Error, InvalidAsn1String};
+pub use issuer::Issuer;
 use key_pair::PublicKeyData;
 #[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
 pub use key_pair::RsaKeySize;
@@ -72,6 +73,7 @@ mod certificate;
 mod crl;
 mod csr;
 mod error;
+mod issuer;
 mod key_pair;
 mod oid;
 mod ring_like;
@@ -128,13 +130,6 @@ pub fn generate_simple_self_signed(
 	let key_pair = KeyPair::generate()?;
 	let cert = CertificateParams::new(subject_alt_names)?.self_signed(&key_pair)?;
 	Ok(CertifiedKey { cert, key_pair })
-}
-
-struct Issuer<'a> {
-	distinguished_name: &'a DistinguishedName,
-	key_identifier_method: &'a KeyIdMethod,
-	key_usages: &'a [KeyUsagePurpose],
-	key_pair: &'a KeyPair,
 }
 
 // https://tools.ietf.org/html/rfc5280#section-4.1.1


### PR DESCRIPTION
Motivation #274, based off https://github.com/rustls/rcgen/pull/269#issuecomment-2079282218

Still required before merge:
 - [ ] Finalise the API requirements
 - [ ] Implement it all
 - [ ] Documentation comments
 - [ ] Changelog - This will require a major release!

## Questions

### `rustls_cert_gen::Ca`?

We could either keep it as a wrapper type of `rcgen::Issuer` or phase it out completely.

If we were gonna phase it out I would do it with the following changes:
 - [ ] Drop `rustls_cert_gen::Ca` in favor of `rcgen::Issuer`
 - [ ] Add a conversion from `rcgen::Issuer` to `rcgen::CertifiedKey` using `From` or `to_certified_key` method.
 - [ ] Move `rcgen::PemCertifiedKey::write` to `rcgen::CertifiedKey::write_pem` (replacing `Ca::serialize_pem().write` with `Issuer::to_certified_key().write_pem()`, alternatively we could also just have `Issuer::write_pem`)
 - [ ] Drop `rustls_cert_gen::PemCertifiedKey` in favor of `rcgen::CertifiedKey` (which is fine because the method is now `write_pem` not `write`)
 - [ ] Remove `rustls_cert_gen::EndEntity::serialize_pem` and provide conversion from `rustls_cert_gen::EndEntity` to `rcgen::CertifiedKey` using `From` or `to_certified_key` method.
 - [ ] Should `rustls_cert_gen::EndEntity` just be `rcgen::CertifiedKey` or is that too far?

### `KeyPair` and `Clone`?

I have removed the lifetime from `Issuer` so it holds owned values, as I personally think this is the best call and it was implied by @djc's message linked above.

This does raise an interesting concern, how should `CertificateParams::self_signed` construct an `rcgen::Issuer` as it takes in `&KeyPair` and we would require an owned `KeyPair`.

Options:
 - [ ] Implement `Clone` publically for `KeyPair` and make `CertificateParams::self_signed` take `KeyPair`
 - [ ] Implement `Clone` privately for `KeyPair` and use it
 - [ ] Make `Issuer` hold a `Cow<'a, KeyPair>` and provide an `Issuer::to_owned` method which allocates the data and returns `Issuer<'static>`.
 - [ ] Make `Issuer` hold a lifetime to the `KeyPair`

Option 4 has the major downside that it makes parsing around an `Issuer` really difficult due to it always having a lifetime to some buffer. I know in my personal use of `rcgen` I load the issuer on startup and give it around to Tokio tasks, and it would be nice to avoid leaking memory as would be required with this option.

### `rcgen::Issuer` vs `rcgen::CertifiedKey`?

Aren't these basically the same type.

`rustls_cert_gen::Ca` being either a wrapper or replaced by `rcgen::Issuer` means we need to provide a way to go from an `Issuer` to `Certificate` which we will use to replace/reimplement the existing `rustls_cert_gen::Ca::cert` method.

Given this, I think it seems logical that in code `Issuer` could be:
```rs
pub struct CertifiedKey {
    pub cert: Certificate,
    pub key_pair: KeyPair,
}
```

which is `rcgen::CertifiedKey`.

I could be missing something but if they are the same type I feel like unifying them into one makes sense and simplifies the public API.

### TODO

> The from_ca_cert_*() constructors from CertificateParams move to Issuer, and we see if we can address the documented caveats on those methods.

Gotta do this as @djc noted in the linked message.