### PR TITLE
ci: update cargo-check-external-types toolchain, fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,8 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ matrix.toolchain }}
+        # TODO(XXX): Revert to "matrix.toolchain" after rust-lang/rust#125474 is fixed.
+        toolchain: ${{ matrix.toolchain == 'nightly' && 'nightly-2024-05-22' || matrix.toolchain }}
     - name: Run cargo check
       run: cargo check --all-targets
     - name: Run the tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-05-01
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install --locked cargo-check-external-types
       - name: run cargo-check-external-types for rcgen/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -1170,9 +1170,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
For `cargo-check-external-types`, the upstream project cut a [0.1.12 release](https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.1.12) that now pins Rust nightly-2024-05-01. This commit updates CI to match.

For the `time` dep, a bump in the `Cargo.lock` was required to fix the project build w/ nightly.

Lastly, the project's builds of `main` using nightly are hitting an upstream bug (rust-lang/rust#125474), take the same workaround we landed in Rustls (https://github.com/rustls/rustls/pull/1971) to unbreak the build while this is sorted out.