### PR TITLE
Revert "ci: temp. pin nightly to avoid ICE"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        # TODO(XXX): Revert to "matrix.toolchain" after rust-lang/rust#125474 is fixed.
-        toolchain: ${{ matrix.toolchain == 'nightly' && 'nightly-2024-05-22' || matrix.toolchain }}
+        toolchain: ${{ matrix.toolchain }}
     - name: Run cargo check
       run: cargo check --all-targets
     - name: Run the tests


### PR DESCRIPTION
This reverts commit 74ecacab0c4853ac1a8908669111f286dfeab933 from https://github.com/rustls/rcgen/pull/276. Latest nightly builds/tests without issue.