### PR TITLE
crl: avoid markdown footnotes

### DIFF
--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -142,9 +142,9 @@ fn write_distribution_point_name_uris<'a>(
 }
 
 /// Identifies the reason a certificate was revoked.
-/// See RFC 5280 §5.3.1[^1]
+/// See [RFC 5280 §5.3.1][1]
 ///
-/// [^1] <https://www.rfc-editor.org/rfc/rfc5280#section-5.3.1>
+/// [1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5.3.1>
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[allow(missing_docs)] // Not much to add above the code name.
 pub enum RevocationReason {


### PR DESCRIPTION
Nightly rustdoc flags these as non-standard markdown, and they don't render as nicely as just using a link. See also https://github.com/rustls/rustls/pull/2033, https://github.com/rustls/webpki/pull/268

Fixes [build errors on main](https://github.com/rustls/rcgen/actions/runs/9821174655/job/27116566286).