### PR TITLE
Disable default features for `aws-lc-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,6 @@ dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
  "paste",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -529,9 +528,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -937,7 +936,7 @@ dependencies = [
  "getrandom",
  "libc",
  "spin",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys",
 ]
 
@@ -1019,7 +1018,7 @@ checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -1197,12 +1196,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rcgen", "rustls-cert-gen"]
 resolver = "2"
 
 [workspace.dependencies]
-aws-lc-rs = "1.6.0"
+aws-lc-rs = { version = "1.6.0", default-features = false }
 pem = "3.0.2"
 pki-types = { package = "rustls-pki-types", version = "1.4.1" }
 rand = "0.8"

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -38,9 +38,9 @@ zeroize = { version = "1.2", optional = true }
 [features]
 default = ["crypto", "pem", "ring"]
 crypto = []
-aws_lc_rs = ["crypto", "dep:aws-lc-rs"]
+aws_lc_rs = ["crypto", "dep:aws-lc-rs", "aws-lc-rs/aws-lc-sys"]
 ring = ["crypto", "dep:ring"]
-fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
+fips = ["crypto", "dep:aws-lc-rs", "aws-lc-rs/fips"]
 
 [package.metadata.docs.rs]
 features = ["x509-parser"]

--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -11,9 +11,9 @@ keywords.workspace = true
 
 [features]
 default = ["ring"]
-aws_lc_rs = ["dep:aws-lc-rs", "rcgen/aws_lc_rs"]
+aws_lc_rs = ["dep:aws-lc-rs", "rcgen/aws_lc_rs", "aws-lc-rs/aws-lc-sys"]
 ring = ["dep:ring", "rcgen/ring"]
-fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
+fips = ["dep:aws-lc-rs", "rcgen/aws_lc_rs", "aws-lc-rs/fips"]
 
 [dependencies]
 rcgen = { version = "0.13", path = "../rcgen", default-features = false, features = ["pem"] }


### PR DESCRIPTION
Rcgen doesn't require `aws-lc-rs`'s default features, so disabling them removes some dependencies.