### PR TITLE
make `CertificateParams::signed_by` accept `impl PublicKeyData` rather than `KeyPair` for the key being signed

### DIFF
--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -36,7 +36,7 @@ x509-parser = { workspace = true, features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }
 
 [features]
-default = ["crypto", "pem", "ring"]
+default = ["crypto", "pem", "ring", "x509-parser"]
 crypto = []
 aws_lc_rs = ["crypto", "dep:aws-lc-rs", "aws-lc-rs/aws-lc-sys"]
 ring = ["crypto", "dep:ring"]

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -147,9 +147,9 @@ impl CertificateParams {
 	///
 	/// The returned [`Certificate`] may be serialized using [`Certificate::der`] and
 	/// [`Certificate::pem`].
-	pub fn signed_by(
+	pub fn signed_by<K: PublicKeyData>(
 		self,
-		key_pair: &KeyPair,
+		key_pair: &K,
 		issuer: &Certificate,
 		issuer_key: &KeyPair,
 	) -> Result<Certificate, Error> {
@@ -160,7 +160,8 @@ impl CertificateParams {
 			key_pair: issuer_key,
 		};
 
-		let subject_public_key_info = key_pair.public_key_der();
+		let subject_public_key_info =
+			yasna::construct_der(|writer| key_pair.serialize_public_key_der(writer));
 		let der = self.serialize_der_with_signer(key_pair, issuer)?;
 		Ok(Certificate {
 			params: self,

--- a/rcgen/src/error.rs
+++ b/rcgen/src/error.rs
@@ -45,6 +45,9 @@ pub enum Error {
 	#[cfg(not(feature = "crypto"))]
 	/// Missing serial number
 	MissingSerialNumber,
+	/// X509 parsing error
+	#[cfg(feature = "x509-parser")]
+	X509,
 }
 
 impl fmt::Display for Error {
@@ -91,6 +94,8 @@ impl fmt::Display for Error {
 			)?,
 			#[cfg(not(feature = "crypto"))]
 			MissingSerialNumber => write!(f, "A serial number must be specified")?,
+			#[cfg(feature = "x509-parser")]
+			X509 => write!(f, "X509 error")?,
 		};
 		Ok(())
 	}

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -61,7 +61,7 @@ pub use error::{Error, InvalidAsn1String};
 use key_pair::PublicKeyData;
 #[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
 pub use key_pair::RsaKeySize;
-pub use key_pair::{KeyPair, RemoteKeyPair};
+pub use key_pair::{KeyPair, RemoteKeyPair, SubjectPublicKey};
 #[cfg(feature = "crypto")]
 use ring_like::digest;
 pub use sign_algo::algo::*;


### PR DESCRIPTION
`CertificateParams::signed_by` does not need the secret corresponding to the public key being certified (though of course it needs the secret for the CA key signing the certificate!). More discussion about this in #282.

This PR:
- changes the first arg of `signed_by` to `impl PublicKeyData` (which maintains compatibility because `KeyPair` implements this trait)
- adds a new type, `SubjectPublicKey`, that can be parsed from a PEM or DER output by this crate (or, e.g., by openssl) and also impls `PublicKeyData.` This type is only available when the `x509-parser` feature is enabled (because that's what is required to parse).

I added a quick test that the `SubjectPublicKey` type's `PublicKeyData` impl produces the same output as `KeyPair` would for the same key, at least for the key types that can be generated using the crate. (So this means, no test right now for RSA keys, since those seemed to give an error when I tried to generate a keypair.)