### PR TITLE
lib: use From trait for KeyUsagePurpose -> u16

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -439,7 +439,7 @@ impl CertificateParams {
 		write_x509_extension(writer, oid::KEY_USAGE, true, |writer| {
 			// u16 is large enough to encode the largest possible key usage (two-bytes)
 			let bit_string = self.key_usages.iter().fold(0u16, |bit_string, key_usage| {
-				bit_string | key_usage.to_u16()
+				bit_string | u16::from(*key_usage)
 			});
 			writer.write_bitvec_bytes(&bit_string.to_be_bytes(), KEY_USAGE_BITS);
 		});

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -436,23 +436,6 @@ pub enum KeyUsagePurpose {
 }
 
 impl KeyUsagePurpose {
-	/// Encode a key usage as the value of a BIT STRING as defined by RFC 5280.
-	/// [`u16`] is sufficient to encode the largest possible key usage value (two bytes).
-	fn to_u16(&self) -> u16 {
-		const FLAG: u16 = 0b1000_0000_0000_0000;
-		FLAG >> match self {
-			KeyUsagePurpose::DigitalSignature => 0,
-			KeyUsagePurpose::ContentCommitment => 1,
-			KeyUsagePurpose::KeyEncipherment => 2,
-			KeyUsagePurpose::DataEncipherment => 3,
-			KeyUsagePurpose::KeyAgreement => 4,
-			KeyUsagePurpose::KeyCertSign => 5,
-			KeyUsagePurpose::CrlSign => 6,
-			KeyUsagePurpose::EncipherOnly => 7,
-			KeyUsagePurpose::DecipherOnly => 8,
-		}
-	}
-
 	/// Parse a collection of key usages from a [`u16`] representing the value
 	/// of a KeyUsage BIT STRING as defined by RFC 5280.
 	#[cfg(feature = "x509-parser")]
@@ -470,10 +453,29 @@ impl KeyUsagePurpose {
 		]
 		.iter()
 		.filter_map(|key_usage| {
-			let present = key_usage.to_u16() & value != 0;
+			let present = u16::from(*key_usage) & value != 0;
 			present.then_some(*key_usage)
 		})
 		.collect()
+	}
+}
+
+/// Encode a key usage as the value of a BIT STRING as defined by RFC 5280.
+/// [`u16`] is sufficient to encode the largest possible key usage value (two bytes).
+impl From<KeyUsagePurpose> for u16 {
+	fn from(value: KeyUsagePurpose) -> Self {
+		const FLAG: u16 = 0b1000_0000_0000_0000;
+		FLAG >> match value {
+			KeyUsagePurpose::DigitalSignature => 0,
+			KeyUsagePurpose::ContentCommitment => 1,
+			KeyUsagePurpose::KeyEncipherment => 2,
+			KeyUsagePurpose::DataEncipherment => 3,
+			KeyUsagePurpose::KeyAgreement => 4,
+			KeyUsagePurpose::KeyCertSign => 5,
+			KeyUsagePurpose::CrlSign => 6,
+			KeyUsagePurpose::EncipherOnly => 7,
+			KeyUsagePurpose::DecipherOnly => 8,
+		}
 	}
 }
 


### PR DESCRIPTION
Quick follow-up from https://github.com/rustls/rcgen/pull/287 Using a `From` impl feels a bit more idiomatic in this case.