### PR TITLE
Fix compilation issues of OpenSSL tests on 32-bit architectures

### DIFF
--- a/rcgen/tests/openssl.rs
+++ b/rcgen/tests/openssl.rs
@@ -422,11 +422,27 @@ fn test_openssl_crl_parse() {
 
 	// The properties of the CRL should match expected.
 	let openssl_issuer = X509::from_der(issuer.der()).unwrap();
-	let expected_last_update =
-		Asn1Time::from_unix(crl.params().this_update.unix_timestamp()).unwrap();
+	// Asn1Time::from_unix takes i64 or i32 (depending on CPU architecture)
+	#[allow(clippy::useless_conversion)]
+	let expected_last_update = Asn1Time::from_unix(
+		crl.params()
+			.this_update
+			.unix_timestamp()
+			.try_into()
+			.unwrap(),
+	)
+	.unwrap();
 	assert!(openssl_crl.last_update().eq(&expected_last_update));
-	let expected_next_update =
-		Asn1Time::from_unix(crl.params().next_update.unix_timestamp()).unwrap();
+	// Asn1Time::from_unix takes i64 or i32 (depending on CPU architecture)
+	#[allow(clippy::useless_conversion)]
+	let expected_next_update = Asn1Time::from_unix(
+		crl.params()
+			.next_update
+			.unix_timestamp()
+			.try_into()
+			.unwrap(),
+	)
+	.unwrap();
 	assert!(openssl_crl.next_update().unwrap().eq(&expected_next_update));
 	assert!(matches!(
 		openssl_crl


### PR DESCRIPTION
We discovered this as a build failure on i686 when packaging this crate for Fedora Linux.

It looks like `openssl::asn1::Asn1Time::from_unix` takes a 64-bit number on 64-bit platforms only, and a 32-bit number on 32-bit platforms.

This PR adds the suggestion that's made by rustc - add `.try_into().unwrap()` to explicitly convert to an u32 (and fail if the number is out of range).