### PR TITLE
Add PKCS#10 attributes to CSR serializer

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -461,6 +461,10 @@ impl CertificateParams {
 	}
 
 	fn write_subject_alt_names(&self, writer: DERWriter) {
+		if self.subject_alt_names.is_empty() {
+			return;
+		}
+
 		write_x509_extension(writer, oid::SUBJECT_ALT_NAME, false, |writer| {
 			writer.write_sequence(|writer| {
 				for san in self.subject_alt_names.iter() {

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -63,7 +63,7 @@ impl From<Certificate> for CertificateDer<'static> {
 /// Parameters used for certificate generation
 #[allow(missing_docs)]
 #[non_exhaustive]
-#[derive(Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CertificateParams {
 	pub not_before: OffsetDateTime,
 	pub not_after: OffsetDateTime,

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -49,8 +49,8 @@ use yasna::DERWriter;
 use yasna::Tag;
 
 pub use certificate::{
-	date_time_ymd, BasicConstraints, Certificate, CertificateParams, CidrSubnet, CustomExtension,
-	DnType, ExtendedKeyUsagePurpose, GeneralSubtree, IsCa, NameConstraints,
+	date_time_ymd, Attribute, BasicConstraints, Certificate, CertificateParams, CidrSubnet,
+	CustomExtension, DnType, ExtendedKeyUsagePurpose, GeneralSubtree, IsCa, NameConstraints,
 };
 pub use crl::{
 	CertificateRevocationList, CertificateRevocationListParams, CrlDistributionPoint,

--- a/rcgen/tests/generic.rs
+++ b/rcgen/tests/generic.rs
@@ -401,7 +401,7 @@ mod test_csr {
 
 		// Ensure algorithms match.
 		assert_eq!(key_pair.algorithm(), csrp.public_key.algorithm());
-		// Ensure key usages match.
-		assert_eq!(csrp.params.key_usages, params.key_usages);
+		// Assert that our parsed parameters match our initial parameters
+		assert_eq!(*params, csrp.params);
 	}
 }

--- a/rcgen/tests/generic.rs
+++ b/rcgen/tests/generic.rs
@@ -360,7 +360,10 @@ mod test_parse_other_name_alt_name {
 
 #[cfg(feature = "x509-parser")]
 mod test_csr {
-	use rcgen::{CertificateParams, CertificateSigningRequestParams, KeyPair, KeyUsagePurpose};
+	use rcgen::{
+		CertificateParams, CertificateSigningRequestParams, ExtendedKeyUsagePurpose, KeyPair,
+		KeyUsagePurpose,
+	};
 
 	#[test]
 	fn test_csr_roundtrip() {
@@ -370,10 +373,7 @@ mod test_csr {
 	}
 
 	#[test]
-	fn test_nontrivial_csr_roundtrip() {
-		let key_pair = KeyPair::generate().unwrap();
-
-		// We should be able to serialize a CSR, and then parse the CSR.
+	fn test_csr_with_key_usages_roundtrip() {
 		let mut params = CertificateParams::default();
 		params.key_usages = vec![
 			KeyUsagePurpose::DigitalSignature,
@@ -388,6 +388,24 @@ mod test_csr {
 			// KeyUsagePurpose::EncipherOnly,
 			KeyUsagePurpose::DecipherOnly,
 		];
+		generate_and_test_parsed_csr(&params);
+	}
+
+	#[test]
+	fn test_csr_with_extended_key_usages_roundtrip() {
+		let mut params = CertificateParams::default();
+		params.extended_key_usages = vec![
+			ExtendedKeyUsagePurpose::ServerAuth,
+			ExtendedKeyUsagePurpose::ClientAuth,
+		];
+		generate_and_test_parsed_csr(&params);
+	}
+
+	#[test]
+	fn test_csr_with_key_usgaes_and_extended_key_usages_roundtrip() {
+		let mut params = CertificateParams::default();
+		params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+		params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
 		generate_and_test_parsed_csr(&params);
 	}
 

--- a/rcgen/tests/generic.rs
+++ b/rcgen/tests/generic.rs
@@ -364,16 +364,9 @@ mod test_csr {
 
 	#[test]
 	fn test_csr_roundtrip() {
-		let key_pair = KeyPair::generate().unwrap();
-
 		// We should be able to serialize a CSR, and then parse the CSR.
-		let csr = CertificateParams::default()
-			.serialize_request(&key_pair)
-			.unwrap();
-		let csrp = CertificateSigningRequestParams::from_der(csr.der()).unwrap();
-
-		// Ensure algorithms match.
-		assert_eq!(key_pair.algorithm(), csrp.public_key.algorithm());
+		let params = CertificateParams::default();
+		generate_and_test_parsed_csr(&params);
 	}
 
 	#[test]
@@ -395,7 +388,15 @@ mod test_csr {
 			// KeyUsagePurpose::EncipherOnly,
 			KeyUsagePurpose::DecipherOnly,
 		];
+		generate_and_test_parsed_csr(&params);
+	}
+
+	fn generate_and_test_parsed_csr(params: &CertificateParams) {
+		// Generate a key pair for the CSR
+		let key_pair = KeyPair::generate().unwrap();
+		// Serialize the CSR into DER from the given parameters
 		let csr = params.serialize_request(&key_pair).unwrap();
+		// Parse the CSR we just serialized
 		let csrp = CertificateSigningRequestParams::from_der(csr.der()).unwrap();
 
 		// Ensure algorithms match.

--- a/rcgen/tests/generic.rs
+++ b/rcgen/tests/generic.rs
@@ -375,6 +375,25 @@ mod test_csr_extension_request {
 			.unwrap()
 			.any(|ext| matches!(ext, ParsedExtension::SubjectAlternativeName(_))));
 	}
+
+	#[test]
+	fn write_extension_request_if_ekus_are_present() {
+		let mut params = CertificateParams::default();
+		params
+			.extended_key_usages
+			.push(ExtendedKeyUsagePurpose::ClientAuth);
+		let key_pair = KeyPair::generate().unwrap();
+		let csr = params.serialize_request(&key_pair).unwrap();
+		let (_, parsed_csr) = X509CertificationRequest::from_der(csr.der()).unwrap();
+		let requested_extensions = parsed_csr
+			.requested_extensions()
+			.unwrap()
+			.collect::<Vec<_>>();
+		assert!(matches!(
+			requested_extensions.first().unwrap(),
+			ParsedExtension::ExtendedKeyUsage(_)
+		));
+	}
 }
 
 #[cfg(feature = "x509-parser")]

--- a/rcgen/tests/generic.rs
+++ b/rcgen/tests/generic.rs
@@ -359,6 +359,25 @@ mod test_parse_other_name_alt_name {
 }
 
 #[cfg(feature = "x509-parser")]
+mod test_csr_extension_request {
+	use rcgen::{CertificateParams, ExtendedKeyUsagePurpose, KeyPair, KeyUsagePurpose};
+	use x509_parser::prelude::{FromDer, ParsedExtension, X509CertificationRequest};
+
+	#[test]
+	fn dont_write_sans_extension_if_no_sans_are_present() {
+		let mut params = CertificateParams::default();
+		params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+		let key_pair = KeyPair::generate().unwrap();
+		let csr = params.serialize_request(&key_pair).unwrap();
+		let (_, parsed_csr) = X509CertificationRequest::from_der(csr.der()).unwrap();
+		assert!(!parsed_csr
+			.requested_extensions()
+			.unwrap()
+			.any(|ext| matches!(ext, ParsedExtension::SubjectAlternativeName(_))));
+	}
+}
+
+#[cfg(feature = "x509-parser")]
 mod test_csr {
 	use rcgen::{
 		CertificateParams, CertificateSigningRequestParams, ExtendedKeyUsagePurpose, KeyPair,


### PR DESCRIPTION
Coming from https://github.com/rustls/rcgen/issues/285, this PR adds PKCS#10 attributes to rcgen's CSR serialization logic.
Of course, rcgen has already implicitly supported at most one attribute in the form of PKCS#9's extensionRequest[^1], but this allows you to add others.

I haven't split up the commits yet in anticipation of review comments, but the rough changes are (as of writing):
- Add an `Attribute` type that represents an RFC 5280[^2]/RFC 2986[^3] (take your pick) ATTRIBUTE.
- Add a `custom_csr_attributes` field to `CertificateParams`, of type `Attribute`
- Add serialization logic for `custom_csr_attributes` in `CertificateParams::serialize_request`
- Add an end-to-end/roundtrip test for CSR serialization with custom attributes
- Add to and update existing CSR serialization tests

Along the way, I've updated a few items that may or may not count as bugs. These are all subtle, so feel free to be pedantic when reviewing them:
- Don't write out DER for SANs if no SANs are specified. The current output isn't technically malformed ("hey, here are 0 SANs"), but it might be unexpected. Edit: yeah, the current behavior violates RFC 5280, see https://github.com/rustls/rcgen/pull/296#discussion_r1823012181 
- _Do_ still write out DER for certificate extensions in the edge case that someone wants an EKU but hasn't specified any standard key usages. The current behavior forgets to put that in the CSR. I believe it's RFC-compliant to do this (i.e. neither PKCS#9, PKCS#10 nor RFC 5280 say you can't), so the current behavior feels like a bug to me.
- Write CSR attributes using an implicit ASN.1 tag instead of an explicit one (see https://github.com/qnighy/yasna.rs/issues/8). This also correctly forces us to encode attributes as an implicit SET OF. I believe the current implementation encodes a single attribute correctly, but it's almost by accident, and definitely doesn't work if you want a number of attributes that isn't 0 or 1.

[^1]: https://datatracker.ietf.org/doc/html/rfc2985
[^2]: https://datatracker.ietf.org/doc/html/rfc5280
[^3]: https://datatracker.ietf.org/doc/html/rfc2986