### PR TITLE
ci: adjust nightly for cargo-check-external-types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-05-01
+          toolchain: nightly-2024-06-30
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install --locked cargo-check-external-types
       - name: run cargo-check-external-types for rcgen/


### PR DESCRIPTION
See the upstream release notes:
  https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.1.13
  
Fixes [build break](https://github.com/rustls/rcgen/actions/runs/11617500782/job/32352862400) of the associated task on main.