### PR TITLE
change signature of signed_by to accept &impl AsRef<CertificateParams> issuer

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -60,6 +60,12 @@ impl From<Certificate> for CertificateDer<'static> {
 	}
 }
 
+impl AsRef<CertificateParams> for Certificate {
+	fn as_ref(&self) -> &CertificateParams {
+		&self.params
+	}
+}
+
 /// Parameters used for certificate generation
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -150,13 +156,13 @@ impl CertificateParams {
 	pub fn signed_by(
 		self,
 		public_key: &impl PublicKeyData,
-		issuer: &Certificate,
+		issuer: &impl AsRef<Self>,
 		issuer_key: &KeyPair,
 	) -> Result<Certificate, Error> {
 		let issuer = Issuer {
-			distinguished_name: &issuer.params.distinguished_name,
-			key_identifier_method: &issuer.params.key_identifier_method,
-			key_usages: &issuer.params.key_usages,
+			distinguished_name: &issuer.as_ref().distinguished_name,
+			key_identifier_method: &issuer.as_ref().key_identifier_method,
+			key_usages: &issuer.as_ref().key_usages,
 			key_pair: issuer_key,
 		};
 
@@ -840,6 +846,12 @@ impl CertificateParams {
 		if !self.extended_key_usages.contains(&eku) {
 			self.extended_key_usages.push(eku);
 		}
+	}
+}
+
+impl AsRef<CertificateParams> for CertificateParams {
+	fn as_ref(&self) -> &CertificateParams {
+		self
 	}
 }
 


### PR DESCRIPTION
I had the issue that I wanted to use an issuer that was a `CertificateParams`, not a `Certificate` (because CertificateParams can be deserialized from file, but Certificate can not). The best solution I've found is to change the signature to accept `&impl AsRef<CertificateParams>`, and then implement that `AsRef` for both `Certificate` and `CertificateParams`.

I think this is also a backwards-compatible change, but I'm not 100% sure.