### PR TITLE
refactor: Generalize csr/crl signed_by to take &impl AsRef issuer

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -157,7 +157,7 @@ impl CertificateParams {
 	pub fn signed_by(
 		self,
 		public_key: &impl PublicKeyData,
-		issuer: &impl AsRef<Self>,
+		issuer: &impl AsRef<CertificateParams>,
 		issuer_key: &KeyPair,
 	) -> Result<Certificate, Error> {
 		let issuer = Issuer {

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -9,7 +9,7 @@ use yasna::Tag;
 use crate::ENCODE_CONFIG;
 use crate::{
 	oid, write_distinguished_name, write_dt_utc_or_generalized,
-	write_x509_authority_key_identifier, write_x509_extension, Certificate, Error, Issuer,
+	write_x509_authority_key_identifier, write_x509_extension, CertificateParams, Error, Issuer,
 	KeyIdMethod, KeyPair, KeyUsagePurpose, SerialNumber,
 };
 
@@ -188,7 +188,7 @@ impl CertificateRevocationListParams {
 	/// Including a signature from the issuing certificate authority's key.
 	pub fn signed_by(
 		self,
-		issuer: &Certificate,
+		issuer: &impl AsRef<CertificateParams>,
 		issuer_key: &KeyPair,
 	) -> Result<CertificateRevocationList, Error> {
 		if self.next_update.le(&self.this_update) {
@@ -196,9 +196,9 @@ impl CertificateRevocationListParams {
 		}
 
 		let issuer = Issuer {
-			distinguished_name: &issuer.params.distinguished_name,
-			key_identifier_method: &issuer.params.key_identifier_method,
-			key_usages: &issuer.params.key_usages,
+			distinguished_name: &issuer.as_ref().distinguished_name,
+			key_identifier_method: &issuer.as_ref().key_identifier_method,
+			key_usages: &issuer.as_ref().key_usages,
 			key_pair: issuer_key,
 		};
 

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -192,7 +192,8 @@ impl CertificateSigningRequestParams {
 	///
 	/// The returned certificate will have its issuer field set to the subject of the provided
 	/// `issuer`, and the authority key identifier extension will be populated using the subject
-	/// public key of `issuer`. It will be signed by `issuer_key`.
+	/// public key of `issuer` (typically either a [`CertificateParams`] or
+	/// [`Certificate`]). It will be signed by `issuer_key`.
 	///
 	/// Note that no validation of the `issuer` certificate is performed. Rcgen will not require
 	/// the certificate to be a CA certificate, or have key usage extensions that allow signing.
@@ -201,13 +202,13 @@ impl CertificateSigningRequestParams {
 	/// [`Certificate::pem`].
 	pub fn signed_by(
 		self,
-		issuer: &Certificate,
+		issuer: &impl AsRef<CertificateParams>,
 		issuer_key: &KeyPair,
 	) -> Result<Certificate, Error> {
 		let issuer = Issuer {
-			distinguished_name: &issuer.params.distinguished_name,
-			key_identifier_method: &issuer.params.key_identifier_method,
-			key_usages: &issuer.params.key_usages,
+			distinguished_name: &issuer.as_ref().distinguished_name,
+			key_identifier_method: &issuer.as_ref().key_identifier_method,
+			key_usages: &issuer.as_ref().key_usages,
 			key_pair: issuer_key,
 		};
 


### PR DESCRIPTION
Completes #307 by applying the same treatment to `csr` and `crl`.

Also improves `CertificateParams::signed_by` issuer from `AsRef<Self>` to `AsRef<CertificateParams>`, because I think it's irrelevant that the issuer is the same type as the CertificateParams being signed, thus `Self` should not be used. 