### PR TITLE
Elide private key in KeyPair Debug impl

### DIFF
--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -64,11 +64,20 @@ impl fmt::Debug for KeyPairKind {
 /// `openssl genrsa` doesn't work. See ring's [documentation](ring::signature::RsaKeyPair::from_pkcs8)
 /// for how to generate RSA keys in the wanted format
 /// and conversion between the formats.
-#[derive(Debug)]
 pub struct KeyPair {
 	pub(crate) kind: KeyPairKind,
 	pub(crate) alg: &'static SignatureAlgorithm,
 	pub(crate) serialized_der: Vec<u8>,
+}
+
+impl fmt::Debug for KeyPair {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("KeyPair")
+			.field("kind", &self.kind)
+			.field("alg", &self.alg)
+			.field("serialized_der", &"[secret key elided]")
+			.finish()
+	}
 }
 
 impl KeyPair {


### PR DESCRIPTION
This closes https://github.com/rustls/rcgen/issues/313 by manually implementing `Debug` for `KeyPair` to elide the PKCS#8 private key bytes that would otherwise be displayed for its `serialized_der` member.

I did this similarly to [rustls/pki-types](https://github.com/rustls/pki-types).

## Before

```rust
KeyPair { kind: EcdsaKeyPair { public_key: EcdsaPublicKey("040888dd433ae8faffeed2cb21ddad501dd470167bd8dfd48f90242d1b1fca1822c8e4cd53d6e993c61f2cf4a5b1a6f270a57c0836dfb9273d3df1c5677020e419") }, alg: PKCS_ECDSA_P256_SHA256, serialized_der: [48, 129, 135, 2, 1, 0, 48, 19, 6, 7, 42, 134, 72, 206, 61, 2, 1, 6, 8, 42, 134, 72, 206, 61, 3, 1, 7, 4, 109, 48, 107, 2, 1, 1, 4, 32, 17, 196, 129, 135, 217, 93, 38, 238, 38, 166, 163, 117, 235, 39, 184, 165, 40, 117, 21, 219, 111, 214, 131, 91, 103, 42, 103, 248, 43, 244, 78, 130, 161, 68, 3, 66, 0, 4, 8, 136, 221, 67, 58, 232, 250, 255, 238, 210, 203, 33, 221, 173, 80, 29, 212, 112, 22, 123, 216, 223, 212, 143, 144, 36, 45, 27, 31, 202, 24, 34, 200, 228, 205, 83, 214, 233, 147, 198, 31, 44, 244, 165, 177, 166, 242, 112, 165, 124, 8, 54, 223, 185, 39, 61, 61, 241, 197, 103, 112, 32, 228, 25] }
```

## After

```rust
KeyPair { kind: EcdsaKeyPair { public_key: PublicKey("04067c4abf6e796dbb57dc7105a1f8b13e45ccb5f63815acce935cfd7b307fa0af65bd2355d4648bf4a0f86f1bbfae55bce2cf4f21aba3e711a94b8336d0c2ec91") }, alg: PKCS_ECDSA_P256_SHA256, serialized_der: "[secret key elided]" }
```