### PR TITLE
Make `Certificate` cloneable (derive `Clone`)

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// An issued certificate together with the parameters used to generate it.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Certificate {
 	pub(crate) params: CertificateParams,
 	pub(crate) subject_public_key_info: Vec<u8>,


### PR DESCRIPTION
Make `Certificate` cloneable (derive `Clone`)

Part of https://github.com/rustls/rcgen/issues/17

> `CertificateParms` is clone now. `Certificate` is not, but I think we'd accept a PR to make it so.
> 
> *-- https://github.com/rustls/rcgen/issues/17#issuecomment-2025329460*



In a similar vein for deriving `Debug` for `Certificate` in https://github.com/rustls/rcgen/commit/362e78a18495a6c7bcbd66f46e7ee56f28f88c5a