### PR TITLE
Revert impl AsRef issuer

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -61,6 +61,12 @@ impl From<Certificate> for CertificateDer<'static> {
 	}
 }
 
+impl AsRef<CertificateParams> for Certificate {
+	fn as_ref(&self) -> &CertificateParams {
+		&self.params
+	}
+}
+
 /// Parameters used for certificate generation
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -845,6 +851,12 @@ impl CertificateParams {
 		if !self.extended_key_usages.contains(&eku) {
 			self.extended_key_usages.push(eku);
 		}
+	}
+}
+
+impl AsRef<CertificateParams> for CertificateParams {
+	fn as_ref(&self) -> &CertificateParams {
+		self
 	}
 }
 

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -158,7 +158,7 @@ impl CertificateParams {
 	pub fn signed_by(
 		self,
 		public_key: &impl PublicKeyData,
-		issuer: &impl AsRef<CertificateParams>,
+		issuer: &impl AsRef<Self>,
 		issuer_key: &KeyPair,
 	) -> Result<Certificate, Error> {
 		let issuer = Issuer {

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -61,12 +61,6 @@ impl From<Certificate> for CertificateDer<'static> {
 	}
 }
 
-impl AsRef<CertificateParams> for Certificate {
-	fn as_ref(&self) -> &CertificateParams {
-		&self.params
-	}
-}
-
 /// Parameters used for certificate generation
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -158,13 +152,13 @@ impl CertificateParams {
 	pub fn signed_by(
 		self,
 		public_key: &impl PublicKeyData,
-		issuer: &impl AsRef<Self>,
+		issuer: &Certificate,
 		issuer_key: &KeyPair,
 	) -> Result<Certificate, Error> {
 		let issuer = Issuer {
-			distinguished_name: &issuer.as_ref().distinguished_name,
-			key_identifier_method: &issuer.as_ref().key_identifier_method,
-			key_usages: &issuer.as_ref().key_usages,
+			distinguished_name: &issuer.params.distinguished_name,
+			key_identifier_method: &issuer.params.key_identifier_method,
+			key_usages: &issuer.params.key_usages,
 			key_pair: issuer_key,
 		};
 
@@ -851,12 +845,6 @@ impl CertificateParams {
 		if !self.extended_key_usages.contains(&eku) {
 			self.extended_key_usages.push(eku);
 		}
-	}
-}
-
-impl AsRef<CertificateParams> for CertificateParams {
-	fn as_ref(&self) -> &CertificateParams {
-		self
 	}
 }
 

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -9,7 +9,7 @@ use yasna::Tag;
 use crate::ENCODE_CONFIG;
 use crate::{
 	oid, write_distinguished_name, write_dt_utc_or_generalized,
-	write_x509_authority_key_identifier, write_x509_extension, CertificateParams, Error, Issuer,
+	write_x509_authority_key_identifier, write_x509_extension, Certificate, Error, Issuer,
 	KeyIdMethod, KeyPair, KeyUsagePurpose, SerialNumber,
 };
 
@@ -190,7 +190,7 @@ impl CertificateRevocationListParams {
 	/// Including a signature from the issuing certificate authority's key.
 	pub fn signed_by(
 		self,
-		issuer: &impl AsRef<CertificateParams>,
+		issuer: &Certificate,
 		issuer_key: &KeyPair,
 	) -> Result<CertificateRevocationList, Error> {
 		if self.next_update.le(&self.this_update) {
@@ -198,9 +198,9 @@ impl CertificateRevocationListParams {
 		}
 
 		let issuer = Issuer {
-			distinguished_name: &issuer.as_ref().distinguished_name,
-			key_identifier_method: &issuer.as_ref().key_identifier_method,
-			key_usages: &issuer.as_ref().key_usages,
+			distinguished_name: &issuer.params.distinguished_name,
+			key_identifier_method: &issuer.params.key_identifier_method,
+			key_usages: &issuer.params.key_usages,
 			key_pair: issuer_key,
 		};
 

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -194,8 +194,7 @@ impl CertificateSigningRequestParams {
 	///
 	/// The returned certificate will have its issuer field set to the subject of the provided
 	/// `issuer`, and the authority key identifier extension will be populated using the subject
-	/// public key of `issuer` (typically either a [`CertificateParams`] or
-	/// [`Certificate`]). It will be signed by `issuer_key`.
+	/// public key of `issuer`. It will be signed by `issuer_key`.
 	///
 	/// Note that no validation of the `issuer` certificate is performed. Rcgen will not require
 	/// the certificate to be a CA certificate, or have key usage extensions that allow signing.
@@ -204,13 +203,13 @@ impl CertificateSigningRequestParams {
 	/// [`Certificate::pem`].
 	pub fn signed_by(
 		self,
-		issuer: &impl AsRef<CertificateParams>,
+		issuer: &Certificate,
 		issuer_key: &KeyPair,
 	) -> Result<Certificate, Error> {
 		let issuer = Issuer {
-			distinguished_name: &issuer.as_ref().distinguished_name,
-			key_identifier_method: &issuer.as_ref().key_identifier_method,
-			key_usages: &issuer.as_ref().key_usages,
+			distinguished_name: &issuer.params.distinguished_name,
+			key_identifier_method: &issuer.params.key_identifier_method,
+			key_usages: &issuer.params.key_usages,
 			key_pair: issuer_key,
 		};
 


### PR DESCRIPTION
Reverts #307 and #312 because they broke semver (#324) .

I'll make a followup that re-introduces this feature using another set of methods.