### PR TITLE
Fixes KeyPair Ownership and Removes Need for Issuer Lifetimes

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -166,6 +166,7 @@ impl CertificateParams {
 			key_identifier_method: &issuer.params.key_identifier_method,
 			key_usages: &issuer.params.key_usages,
 			key_pair: issuer_key,
+			certificate: Some(issuer.clone()),
 		};
 
 		let subject_public_key_info =
@@ -188,6 +189,7 @@ impl CertificateParams {
 			key_identifier_method: &self.key_identifier_method,
 			key_usages: &self.key_usages,
 			key_pair,
+			certificate: None,
 		};
 
 		let subject_public_key_info = key_pair.public_key_der();

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -674,7 +674,7 @@ impl CertificateParams {
 				}
 			};
 			// Write signature algorithm
-			issuer.key_pair.alg.write_alg_ident(writer.next());
+			issuer.key_pair.algorithm().write_alg_ident(writer.next());
 			// Write issuer name
 			write_distinguished_name(writer.next(), &issuer.distinguished_name);
 			// Write validity

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -202,6 +202,7 @@ impl CertificateRevocationListParams {
 			key_identifier_method: &issuer.params.key_identifier_method,
 			key_usages: &issuer.params.key_usages,
 			key_pair: issuer_key,
+			certificate: Some(issuer.clone()),
 		};
 
 		if !issuer.key_usages.is_empty() && !issuer.key_usages.contains(&KeyUsagePurpose::CrlSign) {

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -232,7 +232,7 @@ impl CertificateRevocationListParams {
 			// RFC 5280 §5.1.2.2:
 			//   This field MUST contain the same algorithm identifier as the
 			//   signatureAlgorithm field in the sequence CertificateList
-			issuer.key_pair.alg.write_alg_ident(writer.next());
+			issuer.key_pair.algorithm().write_alg_ident(writer.next());
 
 			// Write issuer.
 			// RFC 5280 §5.1.2.3:

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -211,6 +211,7 @@ impl CertificateSigningRequestParams {
 			key_identifier_method: &issuer.params.key_identifier_method,
 			key_usages: &issuer.params.key_usages,
 			key_pair: issuer_key,
+			certificate: Some(issuer.clone()),
 		};
 
 		let der = self

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -7,7 +7,7 @@ use pki_types::CertificateSigningRequestDer;
 #[cfg(feature = "pem")]
 use crate::ENCODE_CONFIG;
 use crate::{
-	key_pair::serialize_public_key_der, Certificate, CertificateParams, Error, Issuer, KeyPair,
+	key_pair::serialize_public_key_der, Certificate, CertificateParams, Error, Issuer,
 	PublicKeyData, SignatureAlgorithm,
 };
 #[cfg(feature = "x509-parser")]
@@ -201,19 +201,7 @@ impl CertificateSigningRequestParams {
 	///
 	/// The returned [`Certificate`] may be serialized using [`Certificate::der`] and
 	/// [`Certificate::pem`].
-	pub fn signed_by(
-		self,
-		issuer: &Certificate,
-		issuer_key: &KeyPair,
-	) -> Result<Certificate, Error> {
-		let issuer = Issuer {
-			distinguished_name: &issuer.params.distinguished_name,
-			key_identifier_method: &issuer.params.key_identifier_method,
-			key_usages: &issuer.params.key_usages,
-			key_pair: issuer_key,
-			certificate: Some(issuer.clone()),
-		};
-
+	pub fn signed_by(self, issuer: &Issuer) -> Result<Certificate, Error> {
 		let der = self
 			.params
 			.serialize_der_with_signer(&self.public_key, issuer)?;

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -84,6 +84,12 @@ impl Issuer {
 	pub fn public_key_der(&self) -> Vec<u8> {
 		self.key_pair.public_key_der()
 	}
+
+	/// Returns the private key of the issuer. The caller had access to this key when creating the issuer, so it is not
+	/// an increase in privilege to return it.
+	pub fn key_pair(&self) -> &KeyPair {
+		&self.key_pair
+	}
 }
 
 impl PublicKeyData for Issuer {

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -1,25 +1,97 @@
-use crate::{Certificate, DistinguishedName, KeyIdMethod, KeyPair, KeyUsagePurpose};
+use pki_types::CertificateDer;
+
+use crate::{
+	Certificate, CertificateParams, DistinguishedName, Error, KeyIdMethod, KeyPair,
+	KeyUsagePurpose, PublicKeyData, SignatureAlgorithm,
+};
 
 /// Holds the information necessary for an issuer of a certificate to sign other certificates. Specifically, it must
 /// have the distinguished name, key identifier method, key usages, and access to the private key.
 ///
 /// Optionally, the issuer may also have the entire issuer's certificate, but for root certificates this cannot be
 /// available, as the root certificate is self-signed.
-pub struct Issuer<'a> {
+pub struct Issuer {
 	/// The distinguished name of the issuer. Used to construct the issuer field in the issued certificate.
-	pub(crate) distinguished_name: &'a DistinguishedName,
+	pub(crate) distinguished_name: DistinguishedName,
 
 	/// The method used to generate the key identifier for the issuer. Must match the method used to generate the
 	/// subject key identifier in the issuer's certificate.
-	pub(crate) key_identifier_method: &'a KeyIdMethod,
+	pub(crate) key_identifier_method: KeyIdMethod,
 
 	/// The key usage purposes associated with the issuer.
-	pub(crate) key_usages: &'a [KeyUsagePurpose],
+	pub(crate) key_usages: Vec<KeyUsagePurpose>,
 
 	/// The key pair of the issuer which includes the private key, though it may be a RemoteKeyPair allowing for a key
 	/// held in an HSM or other secure location to sign the certificate.
-	pub(crate) key_pair: &'a KeyPair,
+	pub(crate) key_pair: KeyPair,
 
 	/// The issuer's certificate, if available. This is typically `None` for root certificates.
 	pub(crate) certificate: Option<Certificate>,
+}
+
+impl Issuer {
+	/// Creates a new issuer from a certificate in DER format and a key pair. The certificate must be a CA certificate
+	/// and the key pair must contain the private key associated with the certificate.
+	#[cfg(feature = "x509-parser")]
+	pub fn new(der: &CertificateDer, key_pair: &KeyPair) -> Result<Self, Error> {
+		// TODO: The certificate contains the public key, which must match the public key in the key pair, or this
+		// issuer is invalid. We should check this error condition.
+
+		let params = CertificateParams::from_ca_cert_der(der)?;
+		let certificate = Certificate {
+			params: params.clone(),
+			subject_public_key_info: key_pair.public_key_der(),
+			der: der.clone().into_owned(),
+		};
+
+		Ok(Self {
+			distinguished_name: params.distinguished_name,
+			key_identifier_method: params.key_identifier_method,
+			key_usages: params.key_usages,
+			key_pair: key_pair.clone(),
+			certificate: Some(certificate),
+		})
+	}
+
+	/// Creates a new issuer from the given parameters and key pair. This is typically used for root certificates, which
+	/// do not initially have a certificate.
+	pub fn new_from_params(params: &CertificateParams, key_pair: &KeyPair) -> Self {
+		Self {
+			distinguished_name: params.distinguished_name.clone(),
+			key_identifier_method: params.key_identifier_method.clone(),
+			key_usages: params.key_usages.clone(),
+			key_pair: key_pair.clone(),
+			certificate: None,
+		}
+	}
+
+	/// Returns the certificate of the issuer, if available. This is typically `None` for root certificates issuers
+	pub fn certificate(&self) -> Option<&Certificate> {
+		self.certificate.as_ref()
+	}
+
+	/// Returns the distinguished name of the issuer.
+	pub fn distinguished_name(&self) -> &DistinguishedName {
+		&self.distinguished_name
+	}
+
+	/// Returns the public key of the issuer
+	pub fn public_key_raw(&self) -> &[u8] {
+		&self.key_pair.public_key_raw()
+	}
+
+	/// Returns the public key of the issuer in der format
+	pub fn public_key_der(&self) -> Vec<u8> {
+		self.key_pair.public_key_der()
+	}
+}
+
+impl PublicKeyData for Issuer {
+	fn der_bytes(&self) -> &[u8] {
+		self.key_pair.der_bytes()
+	}
+
+	fn algorithm(&self) -> &SignatureAlgorithm {
+		self.key_pair.algorithm()
+	}
 }

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -1,4 +1,4 @@
-use crate::{DistinguishedName, KeyIdMethod, KeyPair, KeyUsagePurpose};
+use crate::{Certificate, DistinguishedName, KeyIdMethod, KeyPair, KeyUsagePurpose};
 
 /// Holds the information necessary for an issuer of a certificate to sign other certificates. Specifically, it must
 /// have the distinguished name, key identifier method, key usages, and access to the private key.
@@ -6,12 +6,20 @@ use crate::{DistinguishedName, KeyIdMethod, KeyPair, KeyUsagePurpose};
 /// Optionally, the issuer may also have the entire issuer's certificate, but for root certificates this cannot be
 /// available, as the root certificate is self-signed.
 pub struct Issuer<'a> {
-	/// The distinguished name of the issuer.
+	/// The distinguished name of the issuer. Used to construct the issuer field in the issued certificate.
 	pub(crate) distinguished_name: &'a DistinguishedName,
-	/// The method used to generate the key identifier for the issuer.
+
+	/// The method used to generate the key identifier for the issuer. Must match the method used to generate the
+	/// subject key identifier in the issuer's certificate.
 	pub(crate) key_identifier_method: &'a KeyIdMethod,
+
 	/// The key usage purposes associated with the issuer.
 	pub(crate) key_usages: &'a [KeyUsagePurpose],
-	/// The key pair of the issuer.
+
+	/// The key pair of the issuer which includes the private key, though it may be a RemoteKeyPair allowing for a key
+	/// held in an HSM or other secure location to sign the certificate.
 	pub(crate) key_pair: &'a KeyPair,
+
+	/// The issuer's certificate, if available. This is typically `None` for root certificates.
+	pub(crate) certificate: Option<Certificate>,
 }

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -1,8 +1,9 @@
+#[cfg(feature = "x509-parser")]
 use pki_types::CertificateDer;
 
 use crate::{
-	Certificate, CertificateParams, DistinguishedName, Error, KeyIdMethod, KeyPair,
-	KeyUsagePurpose, PublicKeyData, SignatureAlgorithm,
+	Certificate, CertificateParams, DistinguishedName, KeyIdMethod, KeyPair, KeyUsagePurpose,
+	PublicKeyData, SignatureAlgorithm,
 };
 
 /// Holds the information necessary for an issuer of a certificate to sign other certificates. Specifically, it must
@@ -33,7 +34,7 @@ impl Issuer {
 	/// Creates a new issuer from a certificate in DER format and a key pair. The certificate must be a CA certificate
 	/// and the key pair must contain the private key associated with the certificate.
 	#[cfg(feature = "x509-parser")]
-	pub fn new(der: &CertificateDer, key_pair: &KeyPair) -> Result<Self, Error> {
+	pub fn new(der: &CertificateDer, key_pair: &KeyPair) -> Result<Self, crate::Error> {
 		// TODO: The certificate contains the public key, which must match the public key in the key pair, or this
 		// issuer is invalid. We should check this error condition.
 

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -65,6 +65,11 @@ impl Issuer {
 		}
 	}
 
+	/// Sets the certificate of the issuer.
+	pub fn set_certificate(&mut self, certificate: Certificate) {
+		self.certificate = Some(certificate);
+	}
+
 	/// Returns the certificate of the issuer, if available. This is typically `None` for root certificates issuers
 	pub fn certificate(&self) -> Option<&Certificate> {
 		self.certificate.as_ref()

--- a/rcgen/src/issuer.rs
+++ b/rcgen/src/issuer.rs
@@ -1,0 +1,17 @@
+use crate::{DistinguishedName, KeyIdMethod, KeyPair, KeyUsagePurpose};
+
+/// Holds the information necessary for an issuer of a certificate to sign other certificates. Specifically, it must
+/// have the distinguished name, key identifier method, key usages, and access to the private key.
+///
+/// Optionally, the issuer may also have the entire issuer's certificate, but for root certificates this cannot be
+/// available, as the root certificate is self-signed.
+pub struct Issuer<'a> {
+	/// The distinguished name of the issuer.
+	pub(crate) distinguished_name: &'a DistinguishedName,
+	/// The method used to generate the key identifier for the issuer.
+	pub(crate) key_identifier_method: &'a KeyIdMethod,
+	/// The key usage purposes associated with the issuer.
+	pub(crate) key_usages: &'a [KeyUsagePurpose],
+	/// The key pair of the issuer.
+	pub(crate) key_pair: &'a KeyPair,
+}

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -65,9 +65,9 @@ impl fmt::Debug for KeyPairKind {
 /// for how to generate RSA keys in the wanted format
 /// and conversion between the formats.
 pub struct KeyPair {
-	pub(crate) kind: KeyPairKind,
-	pub(crate) alg: &'static SignatureAlgorithm,
-	pub(crate) serialized_der: Vec<u8>,
+	kind: KeyPairKind,
+	alg: &'static SignatureAlgorithm,
+	serialized_der: Vec<u8>,
 }
 
 impl fmt::Debug for KeyPair {
@@ -81,6 +81,11 @@ impl fmt::Debug for KeyPair {
 }
 
 impl KeyPair {
+	/// Returns the key pair's signature algorithm
+	pub fn signature_algorithm(&self) -> &'static SignatureAlgorithm {
+		self.alg
+	}
+
 	/// Generate a new random [`PKCS_ECDSA_P256_SHA256`] key pair
 	#[cfg(feature = "crypto")]
 	pub fn generate() -> Result<Self, Error> {

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -81,11 +81,6 @@ impl fmt::Debug for KeyPair {
 }
 
 impl KeyPair {
-	/// Returns the key pair's signature algorithm
-	pub fn signature_algorithm(&self) -> &'static SignatureAlgorithm {
-		self.alg
-	}
-
 	/// Generate a new random [`PKCS_ECDSA_P256_SHA256`] key pair
 	#[cfg(feature = "crypto")]
 	pub fn generate() -> Result<Self, Error> {

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -127,7 +127,9 @@ pub fn generate_simple_self_signed(
 	subject_alt_names: impl Into<Vec<String>>,
 ) -> Result<CertifiedKey, Error> {
 	let key_pair = KeyPair::generate()?;
-	let cert = CertificateParams::new(subject_alt_names)?.self_signed(&key_pair)?;
+	let params = CertificateParams::new(subject_alt_names)?;
+	let issuer = Issuer::new_from_params(&params, &key_pair);
+	let cert = params.self_signed(&issuer)?;
 	Ok(CertifiedKey { cert, key_pair })
 }
 

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -57,6 +57,7 @@ pub use crl::{
 };
 pub use csr::{CertificateSigningRequest, CertificateSigningRequestParams, PublicKey};
 pub use error::{Error, InvalidAsn1String};
+pub use issuer::Issuer;
 pub use key_pair::PublicKeyData;
 #[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
 pub use key_pair::RsaKeySize;
@@ -71,6 +72,7 @@ mod certificate;
 mod crl;
 mod csr;
 mod error;
+mod issuer;
 mod key_pair;
 mod oid;
 mod ring_like;
@@ -127,13 +129,6 @@ pub fn generate_simple_self_signed(
 	let key_pair = KeyPair::generate()?;
 	let cert = CertificateParams::new(subject_alt_names)?.self_signed(&key_pair)?;
 	Ok(CertifiedKey { cert, key_pair })
-}
-
-struct Issuer<'a> {
-	distinguished_name: &'a DistinguishedName,
-	key_identifier_method: &'a KeyIdMethod,
-	key_usages: &'a [KeyUsagePurpose],
-	key_pair: &'a KeyPair,
 }
 
 // https://tools.ietf.org/html/rfc5280#section-4.1.1

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -117,15 +117,14 @@ impl CaBuilder {
 		let key_pair = self.alg.to_key_pair()?;
 
 		// Our certificate will be self-signed (issued by the CA itself).
-		let temp_issuer = Issuer::new_from_params(&self.params, &key_pair);
+		let mut issuer = Issuer::new_from_params(&self.params, &key_pair);
 
 		// Sign the certificate with the CA key pair.
-		let cert = self.params.self_signed(&temp_issuer)?;
+		let cert = self.params.self_signed(&issuer)?;
+		issuer.set_certificate(cert);
 
 		// The CA is now an Issuer in its own right and can be used to issue other certificates.
-		Ok(Ca {
-			issuer: Issuer::new(cert.der(), &key_pair)?,
-		})
+		Ok(Ca { issuer })
 	}
 }
 


### PR DESCRIPTION
There was some previous, but incomplete work to simply the parameters need for signing operations. See [previous pull request for Issuer API](https://github.com/rustls/rcgen/pull/275/commits/07181c3c57fb9fdedb04b4ec7370133ef0edebcd). This work was stopped due to KeyPair ownership vs borrow issues.

# Changes
This PR fixes the KeyPair ownership issue by make KeyPair cheap to clone through the use of a reference-counted inner implementation. I used `std::rc::Rc` but this could be easily swapped for `std::sync::Arc` if multi-threading is deemed higher importance than low runtime impact.

Fixing the KeyPair ownership question then enables the Issuer type to encapsulate all information needed for signing operations while still allowing the KeyPair to be used by other code.

## Versioning
This PR *does* change the published signature of `rcgen` functions that sign code, so that needs to be tracked with appropriate semver versioning for `rcgen` at least. The public API of rustls-cert-gen is not affected.

# Background
I am working on a library that allows an AzureKeyVault to be used for PKI storage. The RemoteKeyPair works well for this, allowing the private key to never exist anywhere but locked inside the KV.

However signing using `rcgen` has proved impossible due to the signing functions requiring a full `Certificate` even though it was only used as a wrapper for the `params` field and then only to construct the `Issuer`. The construction of a `Certificate` was also locked inside the library.

My first thought was to simply provide public methods of creating a `Certificate`, but in reviewing the issues and pull requests, I determined the project wanted an update to `Issuer`, so I implemented that change instead.

This PR resolves the problem of requiring a Certificate that I can't create by making the Issuer the thing that performs signing. The issuer requires access to the KeyPair (which can still reference a remote key) and some of the parameters to the certificate, though it does not require a full Certificate. An` Issuer` can be constructed from a `KeyPair` and either `CertificateParams` or `CertificateDer` if the `x509-parser` features is enabled.