### PR TITLE
Move string types to separate module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rcgen"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "aws-lc-rs",
  "botan",

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcgen"
-version = "0.13.3"
+version = "0.14.0"
 documentation = "https://docs.rs/rcgen"
 description.workspace = true
 repository.workspace = true

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -47,6 +47,8 @@ use yasna::tags::{TAG_BMPSTRING, TAG_TELETEXSTRING, TAG_UNIVERSALSTRING};
 use yasna::DERWriter;
 use yasna::Tag;
 
+use crate::string::{BmpString, Ia5String, PrintableString, TeletexString, UniversalString};
+
 pub use certificate::{
 	date_time_ymd, Attribute, BasicConstraints, Certificate, CertificateParams, CidrSubnet,
 	CustomExtension, DnType, ExtendedKeyUsagePurpose, GeneralSubtree, IsCa, NameConstraints,
@@ -65,7 +67,6 @@ pub use key_pair::{KeyPair, RemoteKeyPair, SubjectPublicKeyInfo};
 use ring_like::digest;
 pub use sign_algo::algo::*;
 pub use sign_algo::SignatureAlgorithm;
-pub use string_types::*;
 
 mod certificate;
 mod crl;
@@ -75,7 +76,7 @@ mod key_pair;
 mod oid;
 mod ring_like;
 mod sign_algo;
-mod string_types;
+pub mod string;
 
 /// Type-alias for the old name of [`Error`].
 #[deprecated(

--- a/rcgen/src/string.rs
+++ b/rcgen/src/string.rs
@@ -1,3 +1,5 @@
+//! ASN.1 string types
+
 use std::{fmt, str::FromStr};
 
 use crate::{Error, InvalidAsn1String};
@@ -14,7 +16,7 @@ use crate::{Error, InvalidAsn1String};
 /// You can create a `PrintableString` from [a literal string][`&str`] with [`PrintableString::try_from`]:
 ///
 /// ```
-/// use rcgen::PrintableString;
+/// use rcgen::string::PrintableString;
 /// let hello = PrintableString::try_from("hello").unwrap();
 /// ```
 ///
@@ -156,7 +158,7 @@ impl PartialEq<&String> for PrintableString {
 /// You can create a `Ia5String` from [a literal string][`&str`] with [`Ia5String::try_from`]:
 ///
 /// ```
-/// use rcgen::Ia5String;
+/// use rcgen::string::Ia5String;
 /// let hello = Ia5String::try_from("hello").unwrap();
 /// ```
 ///
@@ -262,7 +264,7 @@ impl PartialEq<&String> for Ia5String {
 /// You can create a `TeletexString` from [a literal string][`&str`] with [`TeletexString::try_from`]:
 ///
 /// ```
-/// use rcgen::TeletexString;
+/// use rcgen::string::TeletexString;
 /// let hello = TeletexString::try_from("hello").unwrap();
 /// ```
 ///
@@ -377,7 +379,7 @@ impl PartialEq<&String> for TeletexString {
 /// You can create a `BmpString` from [a literal string][`&str`] with [`BmpString::try_from`]:
 ///
 /// ```
-/// use rcgen::BmpString;
+/// use rcgen::string::BmpString;
 /// let hello = BmpString::try_from("hello").unwrap();
 /// ```
 ///
@@ -405,7 +407,7 @@ impl BmpString {
 	/// # Examples
 	///
 	/// ```
-	/// use rcgen::BmpString;
+	/// use rcgen::string::BmpString;
 	/// let s = BmpString::try_from("hello").unwrap();
 	///
 	/// assert_eq!(&[0, 104, 0, 101, 0, 108, 0, 108, 0, 111], s.as_bytes());
@@ -496,7 +498,7 @@ impl FromStr for BmpString {
 /// You can create a `UniversalString` from [a literal string][`&str`] with [`UniversalString::try_from`]:
 ///
 /// ```
-/// use rcgen::UniversalString;
+/// use rcgen::string::UniversalString;
 /// let hello = UniversalString::try_from("hello").unwrap();
 /// ```
 ///
@@ -524,7 +526,7 @@ impl UniversalString {
 	/// # Examples
 	///
 	/// ```
-	/// use rcgen::UniversalString;
+	/// use rcgen::string::UniversalString;
 	/// let s = UniversalString::try_from("hello").unwrap();
 	///
 	/// assert_eq!(&[0, 0, 0, 104, 0, 0, 0, 101, 0, 0, 0, 108, 0, 0, 0, 108, 0, 0, 0, 111], s.as_bytes());

--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -16,7 +16,7 @@ ring = ["dep:ring", "rcgen/ring"]
 fips = ["dep:aws-lc-rs", "rcgen/aws_lc_rs", "aws-lc-rs/fips"]
 
 [dependencies]
-rcgen = { version = "0.13", path = "../rcgen", default-features = false, features = ["pem"] }
+rcgen = { version = "0.14", path = "../rcgen", default-features = false, features = ["pem"] }
 bpaf = { version = "0.9.5", features = ["derive"] }
 pem = { workspace = true }
 pki-types = { workspace = true }


### PR DESCRIPTION
Looking at the rustdoc, it's a bit weird to see the string types mixed up with certificate related stuff.

The rename was done because it follows the way `std` names its modules.