### PR TITLE
Distribute methods for parsing params elements from x509

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -206,7 +206,7 @@ impl CertificateParams {
 		let is_ca = IsCa::from_x509(&x509)?;
 		let validity = x509.validity();
 		let subject_alt_names = SanType::from_x509(&x509)?;
-		let key_usages = Self::convert_x509_key_usages(&x509)?;
+		let key_usages = KeyUsagePurpose::from_x509(&x509)?;
 		let extended_key_usages = Self::convert_x509_extended_key_usages(&x509)?;
 		let name_constraints = NameConstraints::from_x509(&x509)?;
 		let serial_number = Some(x509.serial.to_bytes_be().into());
@@ -245,18 +245,6 @@ impl CertificateParams {
 		})
 	}
 
-	#[cfg(feature = "x509-parser")]
-	fn convert_x509_key_usages(
-		x509: &x509_parser::certificate::X509Certificate<'_>,
-	) -> Result<Vec<KeyUsagePurpose>, Error> {
-		let key_usage = x509
-			.key_usage()
-			.or(Err(Error::CouldNotParseCertificate))?
-			.map(|ext| ext.value);
-		// This x509 parser stores flags in reversed bit BIT STRING order
-		let flags = key_usage.map_or(0u16, |k| k.flags).reverse_bits();
-		Ok(KeyUsagePurpose::from_u16(flags))
-	}
 	#[cfg(feature = "x509-parser")]
 	fn convert_x509_extended_key_usages(
 		x509: &x509_parser::certificate::X509Certificate<'_>,

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -205,7 +205,7 @@ impl CertificateParams {
 		let dn = DistinguishedName::from_name(&x509.tbs_certificate.subject)?;
 		let is_ca = IsCa::from_x509(&x509)?;
 		let validity = x509.validity();
-		let subject_alt_names = Self::convert_x509_subject_alternative_name(&x509)?;
+		let subject_alt_names = SanType::from_x509(&x509)?;
 		let key_usages = Self::convert_x509_key_usages(&x509)?;
 		let extended_key_usages = Self::convert_x509_extended_key_usages(&x509)?;
 		let name_constraints = NameConstraints::from_x509(&x509)?;
@@ -245,25 +245,6 @@ impl CertificateParams {
 		})
 	}
 
-	#[cfg(feature = "x509-parser")]
-	fn convert_x509_subject_alternative_name(
-		x509: &x509_parser::certificate::X509Certificate<'_>,
-	) -> Result<Vec<SanType>, Error> {
-		let sans = x509
-			.subject_alternative_name()
-			.or(Err(Error::CouldNotParseCertificate))?
-			.map(|ext| &ext.value.general_names);
-
-		if let Some(sans) = sans {
-			let mut subject_alt_names = Vec::with_capacity(sans.len());
-			for san in sans {
-				subject_alt_names.push(SanType::try_from_general(san)?);
-			}
-			Ok(subject_alt_names)
-		} else {
-			Ok(Vec::new())
-		}
-	}
 	#[cfg(feature = "x509-parser")]
 	fn convert_x509_key_usages(
 		x509: &x509_parser::certificate::X509Certificate<'_>,

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -172,7 +172,7 @@ impl CertificateParams {
 	/// See [`from_ca_cert_der`](Self::from_ca_cert_der) for more details.
 	#[cfg(all(feature = "pem", feature = "x509-parser"))]
 	pub fn from_ca_cert_pem(pem_str: &str) -> Result<Self, Error> {
-		let certificate = pem::parse(pem_str).or(Err(Error::CouldNotParseCertificate))?;
+		let certificate = pem::parse(pem_str).map_err(|_| Error::CouldNotParseCertificate)?;
 		Self::from_ca_cert_der(&certificate.contents().into())
 	}
 
@@ -200,7 +200,7 @@ impl CertificateParams {
 	#[cfg(feature = "x509-parser")]
 	pub fn from_ca_cert_der(ca_cert: &CertificateDer<'_>) -> Result<Self, Error> {
 		let (_remainder, x509) = x509_parser::parse_x509_certificate(ca_cert)
-			.or(Err(Error::CouldNotParseCertificate))?;
+			.map_err(|_| Error::CouldNotParseCertificate)?;
 
 		Ok(CertificateParams {
 			is_ca: IsCa::from_x509(&x509)?,
@@ -805,7 +805,7 @@ impl ExtendedKeyUsagePurpose {
 	fn from_x509(x509: &x509_parser::certificate::X509Certificate<'_>) -> Result<Vec<Self>, Error> {
 		let extended_key_usage = x509
 			.extended_key_usage()
-			.or(Err(Error::CouldNotParseCertificate))?
+			.map_err(|_| Error::CouldNotParseCertificate)?
 			.map(|ext| ext.value);
 
 		let mut extended_key_usages = Vec::new();
@@ -872,7 +872,7 @@ impl NameConstraints {
 	) -> Result<Option<Self>, Error> {
 		let constraints = x509
 			.name_constraints()
-			.or(Err(Error::CouldNotParseCertificate))?
+			.map_err(|_| Error::CouldNotParseCertificate)?
 			.map(|ext| ext.value);
 
 		let Some(constraints) = constraints else {
@@ -1097,7 +1097,7 @@ impl IsCa {
 
 		let basic_constraints = x509
 			.basic_constraints()
-			.or(Err(Error::CouldNotParseCertificate))?
+			.map_err(|_| Error::CouldNotParseCertificate)?
 			.map(|ext| ext.value);
 
 		Ok(match basic_constraints {

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -916,28 +916,26 @@ impl NameConstraints {
 			.or(Err(Error::CouldNotParseCertificate))?
 			.map(|ext| ext.value);
 
-		if let Some(constraints) = constraints {
-			let permitted_subtrees = if let Some(permitted) = &constraints.permitted_subtrees {
-				GeneralSubtree::from_x509(permitted)?
-			} else {
-				Vec::new()
-			};
+		let Some(constraints) = constraints else {
+			return Ok(None);
+		};
 
-			let excluded_subtrees = if let Some(excluded) = &constraints.excluded_subtrees {
-				GeneralSubtree::from_x509(excluded)?
-			} else {
-				Vec::new()
-			};
-
-			let name_constraints = Self {
-				permitted_subtrees,
-				excluded_subtrees,
-			};
-
-			Ok(Some(name_constraints))
+		let permitted_subtrees = if let Some(permitted) = &constraints.permitted_subtrees {
+			GeneralSubtree::from_x509(permitted)?
 		} else {
-			Ok(None)
-		}
+			Vec::new()
+		};
+
+		let excluded_subtrees = if let Some(excluded) = &constraints.excluded_subtrees {
+			GeneralSubtree::from_x509(excluded)?
+		} else {
+			Vec::new()
+		};
+
+		Ok(Some(Self {
+			permitted_subtrees,
+			excluded_subtrees,
+		}))
 	}
 
 	fn is_empty(&self) -> bool {

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -80,7 +80,7 @@ impl CertificateSigningRequestParams {
 	/// See [`from_der`](Self::from_der) for more details.
 	#[cfg(all(feature = "pem", feature = "x509-parser"))]
 	pub fn from_pem(pem_str: &str) -> Result<Self, Error> {
-		let csr = pem::parse(pem_str).or(Err(Error::CouldNotParseCertificationRequest))?;
+		let csr = pem::parse(pem_str).map_err(|_| Error::CouldNotParseCertificationRequest)?;
 		Self::from_der(&csr.contents().into())
 	}
 

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -182,7 +182,7 @@ impl SanType {
 	fn from_x509(x509: &x509_parser::certificate::X509Certificate<'_>) -> Result<Vec<Self>, Error> {
 		let sans = x509
 			.subject_alternative_name()
-			.or(Err(Error::CouldNotParseCertificate))?
+			.map_err(|_| Error::CouldNotParseCertificate)?
 			.map(|ext| &ext.value.general_names);
 
 		let Some(sans) = sans else {
@@ -473,7 +473,7 @@ impl KeyUsagePurpose {
 	fn from_x509(x509: &x509_parser::certificate::X509Certificate<'_>) -> Result<Vec<Self>, Error> {
 		let key_usage = x509
 			.key_usage()
-			.or(Err(Error::CouldNotParseCertificate))?
+			.map_err(|_| Error::CouldNotParseCertificate)?
 			.map(|ext| ext.value);
 		// This x509 parser stores flags in reversed bit BIT STRING order
 		let flags = key_usage.map_or(0u16, |k| k.flags).reverse_bits();

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -185,15 +185,15 @@ impl SanType {
 			.or(Err(Error::CouldNotParseCertificate))?
 			.map(|ext| &ext.value.general_names);
 
-		if let Some(sans) = sans {
-			let mut subject_alt_names = Vec::with_capacity(sans.len());
-			for san in sans {
-				subject_alt_names.push(Self::try_from_general(san)?);
-			}
-			Ok(subject_alt_names)
-		} else {
-			Ok(Vec::new())
+		let Some(sans) = sans else {
+			return Ok(Vec::new());
+		};
+
+		let mut subject_alt_names = Vec::with_capacity(sans.len());
+		for san in sans {
+			subject_alt_names.push(Self::try_from_general(san)?);
 		}
+		Ok(subject_alt_names)
 	}
 }
 

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -250,8 +250,8 @@ impl KeyPairAlgorithm {
 
 				let rng = ring_like::rand::SystemRandom::new();
 				let alg = &rcgen::PKCS_ED25519;
-				let pkcs8_bytes =
-					Ed25519KeyPair::generate_pkcs8(&rng).or(Err(rcgen::Error::RingUnspecified))?;
+				let pkcs8_bytes = Ed25519KeyPair::generate_pkcs8(&rng)
+					.map_err(|_| rcgen::Error::RingUnspecified)?;
 
 				rcgen::KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
@@ -263,7 +263,7 @@ impl KeyPairAlgorithm {
 				let alg = &rcgen::PKCS_ECDSA_P256_SHA256;
 				let pkcs8_bytes =
 					EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, &rng)
-						.or(Err(rcgen::Error::RingUnspecified))?;
+						.map_err(|_| rcgen::Error::RingUnspecified)?;
 				rcgen::KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
 			KeyPairAlgorithm::EcdsaP384 => {
@@ -274,7 +274,7 @@ impl KeyPairAlgorithm {
 				let alg = &rcgen::PKCS_ECDSA_P384_SHA384;
 				let pkcs8_bytes =
 					EcdsaKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, &rng)
-						.or(Err(rcgen::Error::RingUnspecified))?;
+						.map_err(|_| rcgen::Error::RingUnspecified)?;
 
 				rcgen::KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},
@@ -287,7 +287,7 @@ impl KeyPairAlgorithm {
 				let alg = &rcgen::PKCS_ECDSA_P521_SHA512;
 				let pkcs8_bytes =
 					EcdsaKeyPair::generate_pkcs8(&ECDSA_P521_SHA512_ASN1_SIGNING, &rng)
-						.or(Err(rcgen::Error::RingUnspecified))?;
+						.map_err(|_| rcgen::Error::RingUnspecified)?;
 
 				rcgen::KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_bytes.as_ref().into(), alg)
 			},


### PR DESCRIPTION
This takes the processing steps for transforming an `x509_parser::Certificate` into `CertificateParams` and distributes them over the relevant element's types, in preparation for splitting `from_ca_cert_pem()` and `from_ca_cert_der()` from `CertificateParams` (to make it statically obvious that their use is only intended to build an `Issuer`).