### PR TITLE
Eagerly derive Clone, Copy, where possible

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -968,7 +968,7 @@ impl GeneralSubtree {
 	}
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 /// CIDR subnet, as per [RFC 4632](https://tools.ietf.org/html/rfc4632)
 ///
@@ -1080,7 +1080,7 @@ pub fn date_time_ymd(year: i32, month: u8, day: u8) -> OffsetDateTime {
 }
 
 /// Whether the certificate is allowed to sign other certificates
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum IsCa {
 	/// The certificate can only sign itself
 	NoCa,
@@ -1123,7 +1123,7 @@ impl IsCa {
 ///
 /// Sets an optional upper limit on the length of the intermediate certificate chain
 /// length allowed for this CA certificate (not including the end entity certificate).
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum BasicConstraints {
 	/// No constraint
 	Unconstrained,

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -64,7 +64,7 @@ use crate::{
 ///   key_identifier_method: KeyIdMethod::PreSpecified(vec![]),
 /// }.signed_by(&issuer_params, &key_pair).unwrap();
 ///# }
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CertificateRevocationList {
 	der: CertificateRevocationListDer<'static>,
 }
@@ -159,7 +159,7 @@ pub enum RevocationReason {
 }
 
 /// Parameters used for certificate revocation list (CRL) generation
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CertificateRevocationListParams {
 	/// Issue date of the CRL.
 	pub this_update: OffsetDateTime,
@@ -293,7 +293,7 @@ impl CertificateRevocationListParams {
 
 /// A certificate revocation list (CRL) issuing distribution point, to be included in a CRL's
 /// [issuing distribution point extension](https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.5).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CrlIssuingDistributionPoint {
 	/// The CRL's distribution point, containing a sequence of URIs the CRL can be retrieved from.
 	pub distribution_point: CrlDistributionPoint,
@@ -336,7 +336,7 @@ pub enum CrlScope {
 }
 
 /// Parameters used for describing a revoked certificate included in a [`CertificateRevocationList`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RevokedCertParams {
 	/// Serial number identifying the revoked certificate.
 	pub serial_number: SerialNumber,

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -13,7 +13,7 @@ use crate::{
 use crate::{DistinguishedName, SanType};
 
 /// A public key, extracted from a CSR
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PublicKey {
 	raw: Vec<u8>,
 	alg: &'static SignatureAlgorithm,
@@ -37,7 +37,7 @@ impl PublicKeyData for PublicKey {
 }
 
 /// A certificate signing request (CSR) that can be encoded to PEM or DER.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CertificateSigningRequest {
 	pub(crate) der: CertificateSigningRequestDer<'static>,
 }
@@ -66,7 +66,7 @@ impl From<CertificateSigningRequest> for CertificateSigningRequestDer<'static> {
 }
 
 /// Parameters for a certificate signing request
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CertificateSigningRequestParams {
 	/// Parameters for the certificate to be signed.
 	pub params: CertificateParams,

--- a/rcgen/src/error.rs
+++ b/rcgen/src/error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 /// The error type of the rcgen crate
 pub enum Error {
@@ -104,7 +104,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 /// Invalid ASN.1 string type
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum InvalidAsn1String {
 	/// Invalid PrintableString type

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -430,6 +430,7 @@ impl DistinguishedName {
 /**
 Iterator over [`DistinguishedName`] entries
 */
+#[derive(Clone)]
 pub struct DistinguishedNameIterator<'a> {
 	distinguished_name: &'a DistinguishedName,
 	iter: std::slice::Iter<'a, DnType>,

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -10,13 +10,14 @@ use crate::ring_like::signature::{self, EcdsaSigningAlgorithm, EdDSAParameters, 
 use crate::Error;
 
 #[cfg(feature = "crypto")]
+#[derive(Clone)]
 pub(crate) enum SignAlgo {
 	EcDsa(&'static EcdsaSigningAlgorithm),
 	EdDsa(&'static EdDSAParameters),
 	Rsa(&'static dyn RsaEncoding),
 }
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub(crate) enum SignatureAlgorithmParams {
 	/// Omit the parameters
 	None,
@@ -30,6 +31,7 @@ pub(crate) enum SignatureAlgorithmParams {
 }
 
 /// Signature algorithm type
+#[derive(Clone)]
 pub struct SignatureAlgorithm {
 	oids_sign_alg: &'static [&'static [u64]],
 	#[cfg(feature = "crypto")]

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -10,14 +10,14 @@ use crate::ring_like::signature::{self, EcdsaSigningAlgorithm, EdDSAParameters, 
 use crate::Error;
 
 #[cfg(feature = "crypto")]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub(crate) enum SignAlgo {
 	EcDsa(&'static EcdsaSigningAlgorithm),
 	EdDsa(&'static EdDSAParameters),
 	Rsa(&'static dyn RsaEncoding),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum SignatureAlgorithmParams {
 	/// Omit the parameters
 	None,

--- a/rcgen/tests/openssl.rs
+++ b/rcgen/tests/openssl.rs
@@ -40,10 +40,10 @@ fn verify_cert_basic(cert: &Certificate) {
 
 // TODO implement Debug manually instead of
 // deriving it
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct PipeInner([Vec<u8>; 2]);
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct PipeEnd {
 	read_pos: usize,
 	/// Which end of the pipe

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -37,7 +37,7 @@ impl PemCertifiedKey {
 
 /// Builder to configure TLS [CertificateParams] to be finalized
 /// into either a [Ca] or an [EndEntity].
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct CertificateBuilder {
 	params: CertificateParams,
 	alg: KeyPairAlgorithm,
@@ -80,6 +80,7 @@ impl CertificateBuilder {
 }
 
 /// [CertificateParams] from which an [Ca] [Certificate] can be built
+#[derive(Clone)]
 pub struct CaBuilder {
 	params: CertificateParams,
 	alg: KeyPairAlgorithm,
@@ -161,6 +162,7 @@ impl EndEntity {
 }
 
 /// [CertificateParams] from which an [EndEntity] [Certificate] can be built
+#[derive(Clone)]
 pub struct EndEntityBuilder {
 	params: CertificateParams,
 	alg: KeyPairAlgorithm,


### PR DESCRIPTION
Coming from https://github.com/rustls/rcgen/issues/340, this PR derives `Clone` and `Copy` to align rcgen more closely with Rust's [API guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits). Here's how I went about this:

1. Derive `Clone` for as many types as possible in a full codebase pass (finding types by basically grepping for `struct ` and `enum `). Keep making passes until no more types can derive it.
2. Ditto for `Copy`

I've intentionally opted to derive these traits eagerly at first so that types that we _don't_ want to derive `Clone` or `Copy` for will come up in this review. I think most of these make sense, but I could see some being not desirable—e.g., `Copy` for `SignatureAlgorithmParams`. 