### PR TITLE
tests: only test against openssl on Unix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,6 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     - name: Install NASM for aws-lc-rs on Windows
       uses: ilammy/setup-nasm@v1
-    - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-    - run: vcpkg install openssl:x64-windows-static-md
     - name: Run cargo check
       run: cargo check --all-targets
     - name: Run the tests

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -49,9 +49,11 @@ allowed_external_types = [
 ]
 
 [dev-dependencies]
-openssl = "0.10"
 pki-types = { package = "rustls-pki-types", version = "1" }
 x509-parser = { workspace = true, features = ["verify"] }
 rustls-webpki = { version = "0.103", features = ["ring", "std"] }
 botan = { version = "0.11", features = ["vendored"] }
 ring = { workspace = true }
+
+[target."cfg(unix)".dev-dependencies]
+openssl = "0.10"

--- a/rcgen/examples/rsa-irc-openssl.rs
+++ b/rcgen/examples/rsa-irc-openssl.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	use rcgen::{date_time_ymd, CertificateParams, DistinguishedName};
 	use std::fmt::Write;
@@ -30,4 +31,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	fs::write("certs/key.pem", key_pair.serialize_pem().as_bytes())?;
 	fs::write("certs/key.der", key_pair.serialize_der())?;
 	Ok(())
+}
+
+#[cfg(not(unix))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+	// Due to the support burden of running OpenSSL on Windows,
+	// we only support the OpenSSL backend on Unix-like systems.
+	// It should still work on Windows if you have OpenSSL installed.
+	unimplemented!("OpenSSL backend is not supported on Windows");
 }

--- a/rcgen/tests/openssl.rs
+++ b/rcgen/tests/openssl.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "pem")]
+#![cfg(all(unix, feature = "pem"))]
 
 use std::cell::RefCell;
 use std::io::{Error, ErrorKind, Read, Result as ioResult, Write};


### PR DESCRIPTION
For a while now, build-windows has been failing with some non-obvious issues.

First failing run:

- https://github.com/rustls/rcgen/actions/runs/15052227395

Last working run:

- https://github.com/rustls/rcgen/actions/runs/15028005622

Ostensibly, nothing changed between these two runs (including the GitHub runner image and operating system and the `Cargo.lock` file), so I'm not sure what's going on here. Given the way we use OpenSSL (only to test that our generated artifacts are compatible with OpenSSL), I think it's fine to limit such testing to `unix` platforms only, avoiding a bunch of complexity from building OpenSSL on Windows.