### PR TITLE
Provide a non-owning constructor for `Issuer`

### DIFF
--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -158,7 +158,11 @@ impl<'a, S: SigningKey> Issuer<'a, S> {
 		}
 	}
 
-	fn from_params(params: &'a CertificateParams, signing_key: &'a S) -> Self {
+	/// Create a new issuer from the given parameters and signing key references.
+	///
+	/// Use [`Issuer::new`] instead if you want to obtain an [`Issuer`] that owns
+	/// its parameters.
+	pub fn from_params(params: &'a CertificateParams, signing_key: &'a S) -> Self {
 		Self {
 			distinguished_name: Cow::Borrowed(&params.distinguished_name),
 			key_identifier_method: Cow::Borrowed(&params.key_identifier_method),


### PR DESCRIPTION
Hey `rcgen` folks!

I must say I really like what you've done with the new API changes, but I'm really missing a way to sign certificates without giving the issuer ownership of the `KeyPair` (especially frustrating since it's not `Clone`).

Maybe I missed an alternative (maybe there's a newtype around a reference that directly impls `SigningKey`), but this seems like a straight forward enough change.

Do keep in mind that if you accept this PR, you're probably locking yourself into having these `MaybeOwned` in the internal type representation (just thought I'd warn you :) ).

Note: feel free to reject this PR if you don't want that extra surface, I'm gonna newtype `&KeyPair` to get that copy-less use in my project :)