### PR TITLE
Allow splitting CertifiedIssuer into its parts without cloning

### DIFF
--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -177,6 +177,11 @@ impl<'a, S: SigningKey> CertifiedIssuer<'a, S> {
 	pub fn der(&self) -> &CertificateDer<'static> {
 		self.certificate.der()
 	}
+
+	/// Converts the `CertifiedIssuer` into its inner `Issuer` and `Certificate`
+	pub fn into_issuer_and_certificate(self) -> (Issuer<'a, S>, Certificate) {
+		(self.issuer, self.certificate)
+	}
 }
 
 impl<'a, S> Deref for CertifiedIssuer<'a, S> {


### PR DESCRIPTION
This somewhat improves ergonomics for the case where you want to allow alternatively loading the issuer certificate from a file, or generating it when it doesn't exist.

Consider this function:
```rust
fn load_or_generate_ca_certificate(
    ca_certificate_path: &Path,
    ca_keypair_path: &Path
) -> Result<(CertificateDer<'static>, Issuer<'static, KeyPair>)> {
    if ca_certificate_path.exists() && ca_keypair_path.exists() {
        load_ca_certificate(&ca_certificate_path, &ca_keypair_path)
    } else {
        let ca_certificate: CertifiedIssuer<'static, KeyPair> = generate_ca_certificate()?;
        write_ca_certificate(ca_certificate.as_ref(), &ca_certificate_path)?;
        write_ca_keypair(ca_certificate.key(), &ca_keypair_path)?;
        // What now? You can get an Issuer via deref(), but then you have to clone it
       // to get an owned version, and you can get get the certificate via as_ref(), but same here
    }
}
```
`load_ca_certificate` can't return `CertifiedIssuer` (or `rcgen::Certificate`) since that's not possible when loading from a file.

https://github.com/davids-work/kypare/commit/305d95ef985a2c7af1971efc86a85b78edb18762 shows how the addition of `into_issuer_and_certificate` makes this possible without excessive cloning.