### PR TITLE
docs: fix typo in `PKCS_RSA_SHA384` doc comment

### DIFF
--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -127,7 +127,7 @@ pub(crate) mod algo {
 		params: SignatureAlgorithmParams::Null,
 	};
 
-	/// RSA signing with PKCS#1 1.5 padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
+	/// RSA signing with PKCS#1 1.5 padding and SHA-384 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static PKCS_RSA_SHA384: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[RSA_ENCRYPTION],
 		#[cfg(feature = "crypto")]


### PR DESCRIPTION
Changed probably mistakenly copied `SHA-256` to `SHA-384`.