### PR TITLE
Fix regression in key usage purpose encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rcgen"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "aws-lc-rs",
  "botan",

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcgen"
-version = "0.14.2"
+version = "0.14.3"
 documentation = "https://docs.rs/rcgen"
 description.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Key usage purpose encoding regressed in #287.

I don't (yet) really know what I'm doing here, just implementing @ctz's suggestion from the issue to keep this moving.

Anyone want to suggest some tests that would prevent this from regressing again? There are some tests in https://github.com/rustls/rcgen/pull/287/files#diff-1340717e703c8244b2ad18d09955bd825f1565daee83f900a26a5c956b57c125R380 but we should have something that catches this.

Fixes #368.