### PR TITLE
Forward signing and public key data through references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rcgen"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "aws-lc-rs",
  "openssl",

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcgen"
-version = "0.14.4"
+version = "0.14.5"
 documentation = "https://docs.rs/rcgen"
 description.workspace = true
 repository.workspace = true

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -403,7 +403,7 @@ impl CertificateParams {
 		pub_key: &K,
 		issuer: &Issuer<'_, impl SigningKey>,
 	) -> Result<CertificateDer<'static>, Error> {
-		let der = sign_der(&*issuer.signing_key, |writer| {
+		let der = sign_der(&issuer.signing_key, |writer| {
 			let pub_key_spki = pub_key.subject_public_key_info();
 			// Write version
 			writer.next().write_tagged(Tag::context(0), |writer| {

--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -203,7 +203,7 @@ impl CertificateRevocationListParams {
 	}
 
 	fn serialize_der(&self, issuer: &Issuer<'_, impl SigningKey>) -> Result<Vec<u8>, Error> {
-		sign_der(&*issuer.signing_key, |writer| {
+		sign_der(&issuer.signing_key, |writer| {
 			// Write CRL version.
 			// RFC 5280 §5.1.2.1:
 			//   This optional field describes the version of the encoded CRL.  When

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -629,6 +629,12 @@ pub(crate) fn sign_der(
 	})
 }
 
+impl<S: SigningKey + ?Sized> SigningKey for &S {
+	fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, Error> {
+		(*self).sign(msg)
+	}
+}
+
 /// A key that can be used to sign messages
 pub trait SigningKey: PublicKeyData {
 	/// Signs `msg` using the selected algorithm
@@ -715,6 +721,16 @@ impl PublicKeyData for SubjectPublicKeyInfo {
 
 	fn algorithm(&self) -> &'static SignatureAlgorithm {
 		self.alg
+	}
+}
+
+impl<K: PublicKeyData + ?Sized> PublicKeyData for &K {
+	fn der_bytes(&self) -> &[u8] {
+		(*self).der_bytes()
+	}
+
+	fn algorithm(&self) -> &'static SignatureAlgorithm {
+		(*self).algorithm()
 	}
 }
 

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -201,7 +201,7 @@ pub struct Issuer<'a, S> {
 	distinguished_name: Cow<'a, DistinguishedName>,
 	key_identifier_method: Cow<'a, KeyIdMethod>,
 	key_usages: Cow<'a, [KeyUsagePurpose]>,
-	signing_key: MaybeOwned<'a, S>,
+	signing_key: S,
 }
 
 impl<'a, S: SigningKey> Issuer<'a, S> {
@@ -211,7 +211,7 @@ impl<'a, S: SigningKey> Issuer<'a, S> {
 			distinguished_name: Cow::Owned(params.distinguished_name),
 			key_identifier_method: Cow::Owned(params.key_identifier_method),
 			key_usages: Cow::Owned(params.key_usages),
-			signing_key: MaybeOwned::Owned(signing_key),
+			signing_key,
 		}
 	}
 
@@ -219,12 +219,12 @@ impl<'a, S: SigningKey> Issuer<'a, S> {
 	///
 	/// Use [`Issuer::new`] instead if you want to obtain an [`Issuer`] that owns
 	/// its parameters.
-	pub fn from_params(params: &'a CertificateParams, signing_key: &'a S) -> Self {
+	pub fn from_params(params: &'a CertificateParams, signing_key: S) -> Self {
 		Self {
 			distinguished_name: Cow::Borrowed(&params.distinguished_name),
 			key_identifier_method: Cow::Borrowed(&params.key_identifier_method),
 			key_usages: Cow::Borrowed(&params.key_usages),
-			signing_key: MaybeOwned::Borrowed(signing_key),
+			signing_key,
 		}
 	}
 
@@ -256,7 +256,7 @@ impl<'a, S: SigningKey> Issuer<'a, S> {
 			distinguished_name: Cow::Owned(DistinguishedName::from_name(
 				&x509.tbs_certificate.subject,
 			)?),
-			signing_key: MaybeOwned::Owned(signing_key),
+			signing_key,
 		})
 	}
 
@@ -288,22 +288,6 @@ impl<'a, S> fmt::Debug for Issuer<'a, S> {
 			.field("key_usages", key_usages)
 			.field("signing_key", &"[elided]")
 			.finish()
-	}
-}
-
-enum MaybeOwned<'a, T> {
-	Owned(T),
-	Borrowed(&'a T),
-}
-
-impl<T> Deref for MaybeOwned<'_, T> {
-	type Target = T;
-
-	fn deref(&self) -> &Self::Target {
-		match self {
-			MaybeOwned::Owned(t) => t,
-			MaybeOwned::Borrowed(t) => t,
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes #373, hopefully.

## Proposed release notes

Implement `SigningKey` for `&impl SigningKey` to make `Issuer` more broadly useful.