### PR TITLE
Bump time version from 0.3.6 to 0.3.44 to bump deranged version from 0.4.0 to 0.5.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -972,15 +972,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pem = "3.0.2"
 pki-types = { package = "rustls-pki-types", version = "1.4.1" }
 ring = "0.17"
 rustls-webpki = { version = "0.103", features = ["ring", "std"] }
-time = { version = "0.3.6", default-features = false }
+time = { version = "0.3.44", default-features = false }
 x509-parser = "0.18"
 yasna = { version = "0.5.2", features = ["time", "std"] }
 zeroize = { version = "1.2" }


### PR DESCRIPTION
Resolves new ci failure unrelated to a code change:

```text
 Documenting deranged v0.4.0
error[E0557]: feature has been removed
 --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/deranged-0.4.0/src/lib.rs:3:29
  |
3 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
  |                             ^^^^^^^^^^^^ feature has been removed
  |
  = note: removed in 1.58.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
  = note: merged into `doc_cfg`

error: Compilation failed, aborting rustdoc

For more information about this error, try `rustc --explain E0557`.
error: could not document `deranged`
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```