### PR TITLE
For docs generation check, pin nightly to nightly-2025-09-27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                toolchain: [stable, nightly]
+                # Remove pin of nightly version after `rcgen` is updated to use a version of the
+                # `time` crate which resolves https://github.com/jhpratt/deranged/pull/24. This
+                # pin is independent of the nightly version pin for validating external types.
+                toolchain: [stable, nightly-2025-09-27]
         steps:
             - name: Checkout sources
               uses: actions/checkout@v5
@@ -55,15 +58,15 @@ jobs:
             - name: cargo doc (ring)
               run: cargo doc --features ring,pem,x509-parser --document-private-items
               env:
-                  RUSTDOCFLAGS: ${{ matrix.toolchain == 'nightly' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
+                  RUSTDOCFLAGS: ${{ matrix.toolchain == 'nightly-2025-09-27' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
             - name: cargo doc (aws_lc_rs_unstable)
               run: cargo doc --features aws_lc_rs_unstable,pem,x509-parser --document-private-items
               env:
-                  RUSTDOCFLAGS: ${{ matrix.toolchain == 'nightly' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
+                  RUSTDOCFLAGS: ${{ matrix.toolchain == 'nightly-2025-09-27' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
             - name: cargo doc (fips)
               run: cargo doc --no-default-features --features fips --document-private-items
               env:
-                  RUSTDOCFLAGS: ${{ matrix.toolchain == 'nightly' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
+                  RUSTDOCFLAGS: ${{ matrix.toolchain == 'nightly-2025-09-27' && '-Dwarnings --cfg=docsrs' || '-Dwarnings' }}
 
     check-external-types:
         name: Validate external types appearing in public API


### PR DESCRIPTION
Resolves new ci failure introduced by `nightly-2025-09-28`:

```text
 Documenting deranged v0.4.0
error[E0557]: feature has been removed
 --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/deranged-0.4.0/src/lib.rs:3:29
  |
3 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
  |                             ^^^^^^^^^^^^ feature has been removed
  |
  = note: removed in 1.58.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
  = note: merged into `doc_cfg`

error: Compilation failed, aborting rustdoc

For more information about this error, try `rustc --explain E0557`.
error: could not document `deranged`
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

Linked pr from error message:

https://github.com/rust-lang/rust/pull/138907