### PR TITLE
Implement `From<KeyPair> for PrivateKeyDer<'static>`

### DIFF
--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -595,6 +595,20 @@ impl TryFrom<&PrivateKeyDer<'_>> for KeyPair {
 	}
 }
 
+#[cfg(feature = "crypto")]
+impl From<KeyPair> for PrivatePkcs8KeyDer<'static> {
+	fn from(val: KeyPair) -> Self {
+		val.serialize_der().into()
+	}
+}
+
+#[cfg(feature = "crypto")]
+impl From<KeyPair> for PrivateKeyDer<'static> {
+	fn from(val: KeyPair) -> Self {
+		Self::from(PrivatePkcs8KeyDer::from(val))
+	}
+}
+
 /// The key size used for RSA key generation
 #[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
I've stumbled into this when trying to write a simple rustls-driven server with self-signed cert.

The "obvious" and safe way to go from `KeyPair` to `PrivateKeyDer` seems to round-tripping via PEM:
```
rustls::pki_types::PrivateKeyDer::from_pem_slice(
            signing_key.serialize_pem().as_bytes(),
        )
```

But `rcgen::key_pair::KeyPair::serialized_der()` is
```
/// Returns a reference to the serialized key pair (including the private key)
/// in PKCS#8 format in DER
```
and `PrivateKeyDer` can be constructed from such a input.
This avoids memory allocation and PEM roundtripping,
both of which are optional features anyways,
and this conversion is non-failing.

Perhaps it makes sense to provide this QOL interface?