### PR TITLE
Fix incorrect identifier for ML-DSA signature algorithms

### DIFF
--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -268,7 +268,7 @@ pub(crate) mod algo {
 		params: SignatureAlgorithmParams::None,
 	};
 
-	/// ML-DSA-44 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
+	/// ML-DSA-65 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 	pub static PKCS_ML_DSA_65: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[ML_DSA_65],
@@ -278,7 +278,7 @@ pub(crate) mod algo {
 		params: SignatureAlgorithmParams::None,
 	};
 
-	/// ML-DSA-44 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
+	/// ML-DSA-87 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 	pub static PKCS_ML_DSA_87: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[ML_DSA_87],


### PR DESCRIPTION
In the documentation, all `ML-DSA` signature algorithms are identified as `ML-DSA-44`, which is incorrect