### PR TITLE
Rename `SignatureAlgorithm` values a bit

### DIFF
--- a/rcgen/src/crl.rs
+++ b/rcgen/src/crl.rs
@@ -30,7 +30,7 @@ use crate::{
 /// #[cfg(not(feature = "crypto"))]
 /// impl PublicKeyData for MyKeyPair {
 ///   fn der_bytes(&self) -> &[u8] { &self.public_key }
-///   fn algorithm(&self) -> &'static SignatureAlgorithm { &PKCS_ED25519 }
+///   fn algorithm(&self) -> &'static SignatureAlgorithm { &ED25519 }
 /// }
 /// # fn main () {
 /// // Generate a CRL issuer.

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -80,15 +80,15 @@ impl fmt::Debug for KeyPair {
 
 #[cfg(feature = "crypto")]
 impl KeyPair {
-	/// Generate a new random [`PKCS_ECDSA_P256_SHA256`] key pair
+	/// Generate a new random [`ECDSA_P256_SHA256`] key pair
 	#[cfg(feature = "crypto")]
 	pub fn generate() -> Result<Self, Error> {
-		Self::generate_for(&PKCS_ECDSA_P256_SHA256)
+		Self::generate_for(&ECDSA_P256_SHA256)
 	}
 
 	/// Generate a new random key pair for the specified signature algorithm
 	///
-	/// If you're not sure which algorithm to use, [`PKCS_ECDSA_P256_SHA256`] is a good choice.
+	/// If you're not sure which algorithm to use, [`ECDSA_P256_SHA256`] is a good choice.
 	/// If passed an RSA signature algorithm, it depends on the backend whether we return
 	/// a generated key or an error for key generation being unavailable.
 	/// Currently, only `aws-lc-rs` supports RSA key generation.
@@ -236,47 +236,47 @@ impl KeyPair {
 		let rng = &SystemRandom::new();
 		let serialized_der = pkcs8.secret_pkcs8_der().to_vec();
 
-		let kind = if alg == &PKCS_ED25519 {
+		let kind = if alg == &ED25519 {
 			KeyPairKind::Ed(Ed25519KeyPair::from_pkcs8_maybe_unchecked(&serialized_der)._err()?)
-		} else if alg == &PKCS_ECDSA_P256_SHA256 {
+		} else if alg == &ECDSA_P256_SHA256 {
 			KeyPairKind::Ec(ecdsa_from_pkcs8(
 				&signature::ECDSA_P256_SHA256_ASN1_SIGNING,
 				&serialized_der,
 				rng,
 			)?)
-		} else if alg == &PKCS_ECDSA_P384_SHA384 {
+		} else if alg == &ECDSA_P384_SHA384 {
 			KeyPairKind::Ec(ecdsa_from_pkcs8(
 				&signature::ECDSA_P384_SHA384_ASN1_SIGNING,
 				&serialized_der,
 				rng,
 			)?)
-		} else if alg == &PKCS_RSA_SHA256 {
+		} else if alg == &RSA_PKCS1_SHA256 {
 			let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
 			KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA256)
-		} else if alg == &PKCS_RSA_SHA384 {
+		} else if alg == &RSA_PKCS1_SHA384 {
 			let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
 			KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA384)
-		} else if alg == &PKCS_RSA_SHA512 {
+		} else if alg == &RSA_PKCS1_SHA512 {
 			let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
 			KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA512)
-		} else if alg == &PKCS_RSA_PSS_SHA256 {
+		} else if alg == &RSA_PSS_SHA256 {
 			let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
 			KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA256)
 		} else {
 			#[cfg(feature = "aws_lc_rs")]
-			if alg == &PKCS_ECDSA_P521_SHA256 {
+			if alg == &ECDSA_P521_SHA256 {
 				KeyPairKind::Ec(ecdsa_from_pkcs8(
 					&signature::ECDSA_P521_SHA256_ASN1_SIGNING,
 					&serialized_der,
 					rng,
 				)?)
-			} else if alg == &PKCS_ECDSA_P521_SHA384 {
+			} else if alg == &ECDSA_P521_SHA384 {
 				KeyPairKind::Ec(ecdsa_from_pkcs8(
 					&signature::ECDSA_P521_SHA384_ASN1_SIGNING,
 					&serialized_der,
 					rng,
 				)?)
-			} else if alg == &PKCS_ECDSA_P521_SHA512 {
+			} else if alg == &ECDSA_P521_SHA512 {
 				KeyPairKind::Ec(ecdsa_from_pkcs8(
 					&signature::ECDSA_P521_SHA512_ASN1_SIGNING,
 					&serialized_der,
@@ -360,33 +360,33 @@ impl KeyPair {
 
 			let serialized_der = key.secret_der().to_vec();
 
-			let kind = if alg == &PKCS_ED25519 {
+			let kind = if alg == &ED25519 {
 				KeyPairKind::Ed(Ed25519KeyPair::from_pkcs8_maybe_unchecked(&serialized_der)._err()?)
-			} else if alg == &PKCS_ECDSA_P256_SHA256 {
+			} else if alg == &ECDSA_P256_SHA256 {
 				KeyPairKind::Ec(ecdsa_from_private_key_der(
 					&signature::ECDSA_P256_SHA256_ASN1_SIGNING,
 					&serialized_der,
 				)?)
-			} else if alg == &PKCS_ECDSA_P384_SHA384 {
+			} else if alg == &ECDSA_P384_SHA384 {
 				KeyPairKind::Ec(ecdsa_from_private_key_der(
 					&signature::ECDSA_P384_SHA384_ASN1_SIGNING,
 					&serialized_der,
 				)?)
-			} else if alg == &PKCS_ECDSA_P521_SHA512 {
+			} else if alg == &ECDSA_P521_SHA512 {
 				KeyPairKind::Ec(ecdsa_from_private_key_der(
 					&signature::ECDSA_P521_SHA512_ASN1_SIGNING,
 					&serialized_der,
 				)?)
-			} else if alg == &PKCS_RSA_SHA256 {
+			} else if alg == &RSA_PKCS1_SHA256 {
 				let rsakp = rsa_key_pair_from(&serialized_der)._err()?;
 				KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA256)
-			} else if alg == &PKCS_RSA_SHA384 {
+			} else if alg == &RSA_PKCS1_SHA384 {
 				let rsakp = rsa_key_pair_from(&serialized_der)._err()?;
 				KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA384)
-			} else if alg == &PKCS_RSA_SHA512 {
+			} else if alg == &RSA_PKCS1_SHA512 {
 				let rsakp = rsa_key_pair_from(&serialized_der)._err()?;
 				KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA512)
-			} else if alg == &PKCS_RSA_PSS_SHA256 {
+			} else if alg == &RSA_PSS_SHA256 {
 				let rsakp = rsa_key_pair_from(&serialized_der)._err()?;
 				KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA256)
 			} else {
@@ -542,19 +542,19 @@ impl TryFrom<&PrivateKeyDer<'_>> for KeyPair {
 			let pkcs8 = pkcs8.secret_pkcs8_der();
 			let rng = SystemRandom::new();
 			let (kind, alg) = if let Ok(edkp) = Ed25519KeyPair::from_pkcs8_maybe_unchecked(pkcs8) {
-				(KeyPairKind::Ed(edkp), &PKCS_ED25519)
+				(KeyPairKind::Ed(edkp), &ED25519)
 			} else if let Ok(eckp) =
 				ecdsa_from_pkcs8(&signature::ECDSA_P256_SHA256_ASN1_SIGNING, pkcs8, &rng)
 			{
-				(KeyPairKind::Ec(eckp), &PKCS_ECDSA_P256_SHA256)
+				(KeyPairKind::Ec(eckp), &ECDSA_P256_SHA256)
 			} else if let Ok(eckp) =
 				ecdsa_from_pkcs8(&signature::ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8, &rng)
 			{
-				(KeyPairKind::Ec(eckp), &PKCS_ECDSA_P384_SHA384)
+				(KeyPairKind::Ec(eckp), &ECDSA_P384_SHA384)
 			} else if let Ok(rsakp) = RsaKeyPair::from_pkcs8(pkcs8) {
 				(
 					KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA256),
-					&PKCS_RSA_SHA256,
+					&RSA_PKCS1_SHA256,
 				)
 			} else {
 				return Err(Error::CouldNotParseKeyPair);
@@ -575,23 +575,23 @@ impl TryFrom<&PrivateKeyDer<'_>> for KeyPair {
 			};
 
 			let (kind, alg) = if let Ok(edkp) = Ed25519KeyPair::from_pkcs8_maybe_unchecked(key) {
-				(KeyPairKind::Ed(edkp), &PKCS_ED25519)
+				(KeyPairKind::Ed(edkp), &ED25519)
 			} else if let Ok(eckp) =
 				ecdsa_from_private_key_der(&signature::ECDSA_P256_SHA256_ASN1_SIGNING, key)
 			{
-				(KeyPairKind::Ec(eckp), &PKCS_ECDSA_P256_SHA256)
+				(KeyPairKind::Ec(eckp), &ECDSA_P256_SHA256)
 			} else if let Ok(eckp) =
 				ecdsa_from_private_key_der(&signature::ECDSA_P384_SHA384_ASN1_SIGNING, key)
 			{
-				(KeyPairKind::Ec(eckp), &PKCS_ECDSA_P384_SHA384)
+				(KeyPairKind::Ec(eckp), &ECDSA_P384_SHA384)
 			} else if let Ok(eckp) =
 				ecdsa_from_private_key_der(&signature::ECDSA_P521_SHA512_ASN1_SIGNING, key)
 			{
-				(KeyPairKind::Ec(eckp), &PKCS_ECDSA_P521_SHA512)
+				(KeyPairKind::Ec(eckp), &ECDSA_P521_SHA512)
 			} else if let Ok(rsakp) = rsa_key_pair_from(key) {
 				(
 					KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA256),
-					&PKCS_RSA_SHA256,
+					&RSA_PKCS1_SHA256,
 				)
 			} else {
 				return Err(Error::CouldNotParseKeyPair);
@@ -794,13 +794,13 @@ mod test {
 	#[test]
 	fn test_subject_public_key_parsing() {
 		for alg in [
-			&PKCS_ED25519,
-			&PKCS_ECDSA_P256_SHA256,
-			&PKCS_ECDSA_P384_SHA384,
+			&ED25519,
+			&ECDSA_P256_SHA256,
+			&ECDSA_P384_SHA384,
 			#[cfg(feature = "aws_lc_rs")]
-			&PKCS_ECDSA_P521_SHA512,
+			&ECDSA_P521_SHA512,
 			#[cfg(feature = "aws_lc_rs")]
-			&PKCS_RSA_SHA256,
+			&RSA_PKCS1_SHA256,
 		] {
 			let kp = KeyPair::generate_for(alg).expect("keygen");
 			let pem = kp.public_key_pem();
@@ -821,6 +821,6 @@ mod test {
 		let der = pkcs8.as_ref().to_vec();
 
 		let key_pair = KeyPair::try_from(der).unwrap();
-		assert_eq!(key_pair.algorithm(), &PKCS_ECDSA_P256_SHA256);
+		assert_eq!(key_pair.algorithm(), &ECDSA_P256_SHA256);
 	}
 }

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -48,32 +48,32 @@ pub struct SignatureAlgorithm {
 impl fmt::Debug for SignatureAlgorithm {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		use algo::*;
-		if self == &PKCS_RSA_SHA256 {
-			write!(f, "PKCS_RSA_SHA256")
-		} else if self == &PKCS_RSA_SHA384 {
-			write!(f, "PKCS_RSA_SHA384")
-		} else if self == &PKCS_RSA_SHA512 {
-			write!(f, "PKCS_RSA_SHA512")
-		} else if self == &PKCS_RSA_PSS_SHA256 {
-			write!(f, "PKCS_RSA_PSS_SHA256")
-		} else if self == &PKCS_ECDSA_P256_SHA256 {
-			write!(f, "PKCS_ECDSA_P256_SHA256")
-		} else if self == &PKCS_ECDSA_P384_SHA384 {
-			write!(f, "PKCS_ECDSA_P384_SHA384")
-		} else if self == &PKCS_ED25519 {
-			write!(f, "PKCS_ED25519")
+		if self == &RSA_PKCS1_SHA256 {
+			write!(f, "RSA_PKCS1_SHA256")
+		} else if self == &RSA_PKCS1_SHA384 {
+			write!(f, "RSA_PKCS1_SHA384")
+		} else if self == &RSA_PKCS1_SHA512 {
+			write!(f, "RSA_PKCS1_SHA512")
+		} else if self == &RSA_PSS_SHA256 {
+			write!(f, "RSA_PSS_SHA256")
+		} else if self == &ECDSA_P256_SHA256 {
+			write!(f, "ECDSA_P256_SHA256")
+		} else if self == &ECDSA_P384_SHA384 {
+			write!(f, "ECDSA_P384_SHA384")
+		} else if self == &ED25519 {
+			write!(f, "ED25519")
 		} else {
 			#[cfg(feature = "aws_lc_rs")]
-			if self == &PKCS_ECDSA_P521_SHA256 {
-				return write!(f, "PKCS_ECDSA_P521_SHA256");
+			if self == &ECDSA_P521_SHA256 {
+				return write!(f, "ECDSA_P521_SHA256");
 			}
 			#[cfg(feature = "aws_lc_rs")]
-			if self == &PKCS_ECDSA_P521_SHA384 {
-				return write!(f, "PKCS_ECDSA_P521_SHA384");
+			if self == &ECDSA_P521_SHA384 {
+				return write!(f, "ECDSA_P521_SHA384");
 			}
 			#[cfg(feature = "aws_lc_rs")]
-			if self == &PKCS_ECDSA_P521_SHA512 {
-				return write!(f, "PKCS_ECDSA_P521_SHA512");
+			if self == &ECDSA_P521_SHA512 {
+				return write!(f, "ECDSA_P521_SHA512");
 			}
 
 			write!(f, "Unknown")
@@ -100,19 +100,19 @@ impl SignatureAlgorithm {
 	pub(crate) fn iter() -> std::slice::Iter<'static, &'static SignatureAlgorithm> {
 		use algo::*;
 		static ALGORITHMS: &[&SignatureAlgorithm] = &[
-			&PKCS_RSA_SHA256,
-			&PKCS_RSA_SHA384,
-			&PKCS_RSA_SHA512,
+			&RSA_PKCS1_SHA256,
+			&RSA_PKCS1_SHA384,
+			&RSA_PKCS1_SHA512,
 			//&PKCS_RSA_PSS_SHA256,
-			&PKCS_ECDSA_P256_SHA256,
-			&PKCS_ECDSA_P384_SHA384,
+			&ECDSA_P256_SHA256,
+			&ECDSA_P384_SHA384,
 			#[cfg(feature = "aws_lc_rs")]
-			&PKCS_ECDSA_P521_SHA256,
+			&ECDSA_P521_SHA256,
 			#[cfg(feature = "aws_lc_rs")]
-			&PKCS_ECDSA_P521_SHA384,
+			&ECDSA_P521_SHA384,
 			#[cfg(feature = "aws_lc_rs")]
-			&PKCS_ECDSA_P521_SHA512,
-			&PKCS_ED25519,
+			&ECDSA_P521_SHA512,
+			&ED25519,
 		];
 		ALGORITHMS.iter()
 	}
@@ -134,7 +134,7 @@ pub(crate) mod algo {
 	use crate::oid::*;
 
 	/// RSA signing with PKCS#1 1.5 padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
-	pub static PKCS_RSA_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+	pub static RSA_PKCS1_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[RSA_ENCRYPTION],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PKCS1_SHA256),
@@ -144,7 +144,7 @@ pub(crate) mod algo {
 	};
 
 	/// RSA signing with PKCS#1 1.5 padding and SHA-384 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
-	pub static PKCS_RSA_SHA384: SignatureAlgorithm = SignatureAlgorithm {
+	pub static RSA_PKCS1_SHA384: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[RSA_ENCRYPTION],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PKCS1_SHA384),
@@ -154,7 +154,7 @@ pub(crate) mod algo {
 	};
 
 	/// RSA signing with PKCS#1 1.5 padding and SHA-512 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
-	pub static PKCS_RSA_SHA512: SignatureAlgorithm = SignatureAlgorithm {
+	pub static RSA_PKCS1_SHA512: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[RSA_ENCRYPTION],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PKCS1_SHA512),
@@ -169,7 +169,7 @@ pub(crate) mod algo {
 	// support those: https://github.com/briansmith/ring/issues/1353
 	//
 	/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
-	pub(crate) static PKCS_RSA_PSS_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+	pub(crate) static RSA_PSS_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		// We could also use RSA_ENCRYPTION here, but it's recommended
 		// to use ID-RSASSA-PSS if possible.
 		oids_sign_alg: &[RSASSA_PSS],
@@ -185,7 +185,7 @@ pub(crate) mod algo {
 	};
 
 	/// ECDSA signing using the P-256 curves and SHA-256 hashing as per [RFC 5758](https://tools.ietf.org/html/rfc5758#section-3.2)
-	pub static PKCS_ECDSA_P256_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+	pub static ECDSA_P256_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_256_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P256_SHA256_ASN1_SIGNING),
@@ -195,7 +195,7 @@ pub(crate) mod algo {
 	};
 
 	/// ECDSA signing using the P-384 curves and SHA-384 hashing as per [RFC 5758](https://tools.ietf.org/html/rfc5758#section-3.2)
-	pub static PKCS_ECDSA_P384_SHA384: SignatureAlgorithm = SignatureAlgorithm {
+	pub static ECDSA_P384_SHA384: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_384_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P384_SHA384_ASN1_SIGNING),
@@ -210,7 +210,7 @@ pub(crate) mod algo {
 	///
 	/// Only supported with the `aws_lc_rs` backend.
 	#[cfg(feature = "aws_lc_rs")]
-	pub static PKCS_ECDSA_P521_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+	pub static ECDSA_P521_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P521_SHA256_ASN1_SIGNING),
@@ -225,7 +225,7 @@ pub(crate) mod algo {
 	///
 	/// Only supported with the `aws_lc_rs` backend.
 	#[cfg(feature = "aws_lc_rs")]
-	pub static PKCS_ECDSA_P521_SHA384: SignatureAlgorithm = SignatureAlgorithm {
+	pub static ECDSA_P521_SHA384: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P521_SHA384_ASN1_SIGNING),
@@ -238,7 +238,7 @@ pub(crate) mod algo {
 	///
 	/// Only supported with the `aws_lc_rs` backend.
 	#[cfg(feature = "aws_lc_rs")]
-	pub static PKCS_ECDSA_P521_SHA512: SignatureAlgorithm = SignatureAlgorithm {
+	pub static ECDSA_P521_SHA512: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P521_SHA512_ASN1_SIGNING),
@@ -248,7 +248,7 @@ pub(crate) mod algo {
 	};
 
 	/// ED25519 curve signing as per [RFC 8410](https://tools.ietf.org/html/rfc8410)
-	pub static PKCS_ED25519: SignatureAlgorithm = SignatureAlgorithm {
+	pub static ED25519: SignatureAlgorithm = SignatureAlgorithm {
 		// id-Ed25519 in RFC 8410
 		oids_sign_alg: &[&[1, 3, 101, 112]],
 		#[cfg(feature = "crypto")]
@@ -260,31 +260,31 @@ pub(crate) mod algo {
 
 	/// ML-DSA-44 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
-	pub static PKCS_ML_DSA_44: SignatureAlgorithm = SignatureAlgorithm {
-		oids_sign_alg: &[ML_DSA_44],
+	pub static ML_DSA_44: SignatureAlgorithm = SignatureAlgorithm {
+		oids_sign_alg: &[crate::oid::ML_DSA_44],
 		#[cfg(all(feature = "crypto", feature = "aws_lc_rs_unstable"))]
 		sign_alg: SignAlgo::PqDsa(&ML_DSA_44_SIGNING),
-		oid_components: ML_DSA_44,
+		oid_components: crate::oid::ML_DSA_44,
 		params: SignatureAlgorithmParams::None,
 	};
 
 	/// ML-DSA-44 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
-	pub static PKCS_ML_DSA_65: SignatureAlgorithm = SignatureAlgorithm {
-		oids_sign_alg: &[ML_DSA_65],
+	pub static ML_DSA_65: SignatureAlgorithm = SignatureAlgorithm {
+		oids_sign_alg: &[crate::oid::ML_DSA_65],
 		#[cfg(all(feature = "crypto", feature = "aws_lc_rs_unstable"))]
 		sign_alg: SignAlgo::PqDsa(&ML_DSA_65_SIGNING),
-		oid_components: ML_DSA_65,
+		oid_components: crate::oid::ML_DSA_65,
 		params: SignatureAlgorithmParams::None,
 	};
 
 	/// ML-DSA-44 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
-	pub static PKCS_ML_DSA_87: SignatureAlgorithm = SignatureAlgorithm {
-		oids_sign_alg: &[ML_DSA_87],
+	pub static ML_DSA_87: SignatureAlgorithm = SignatureAlgorithm {
+		oids_sign_alg: &[crate::oid::ML_DSA_87],
 		#[cfg(all(feature = "crypto", feature = "aws_lc_rs_unstable"))]
 		sign_alg: SignAlgo::PqDsa(&ML_DSA_87_SIGNING),
-		oid_components: ML_DSA_87,
+		oid_components: crate::oid::ML_DSA_87,
 		params: SignatureAlgorithmParams::None,
 	};
 }

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -84,6 +84,12 @@ impl SignatureAlgorithm {
 			#[cfg(feature = "aws_lc_rs")]
 			&ECDSA_P521_SHA512,
 			&ED25519,
+			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
+			&ML_DSA_44,
+			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
+			&ML_DSA_65,
+			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
+			&ML_DSA_87,
 		];
 		ALGORITHMS.iter()
 	}

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -38,6 +38,7 @@ pub(crate) enum SignatureAlgorithmParams {
 /// Signature algorithm type
 #[derive(Clone)]
 pub struct SignatureAlgorithm {
+	name: &'static str,
 	oids_sign_alg: &'static [&'static [u64]],
 	#[cfg(feature = "crypto")]
 	pub(crate) sign_alg: SignAlgo,
@@ -47,37 +48,7 @@ pub struct SignatureAlgorithm {
 
 impl fmt::Debug for SignatureAlgorithm {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		use algo::*;
-		if self == &RSA_PKCS1_SHA256 {
-			write!(f, "RSA_PKCS1_SHA256")
-		} else if self == &RSA_PKCS1_SHA384 {
-			write!(f, "RSA_PKCS1_SHA384")
-		} else if self == &RSA_PKCS1_SHA512 {
-			write!(f, "RSA_PKCS1_SHA512")
-		} else if self == &RSA_PSS_SHA256 {
-			write!(f, "RSA_PSS_SHA256")
-		} else if self == &ECDSA_P256_SHA256 {
-			write!(f, "ECDSA_P256_SHA256")
-		} else if self == &ECDSA_P384_SHA384 {
-			write!(f, "ECDSA_P384_SHA384")
-		} else if self == &ED25519 {
-			write!(f, "ED25519")
-		} else {
-			#[cfg(feature = "aws_lc_rs")]
-			if self == &ECDSA_P521_SHA256 {
-				return write!(f, "ECDSA_P521_SHA256");
-			}
-			#[cfg(feature = "aws_lc_rs")]
-			if self == &ECDSA_P521_SHA384 {
-				return write!(f, "ECDSA_P521_SHA384");
-			}
-			#[cfg(feature = "aws_lc_rs")]
-			if self == &ECDSA_P521_SHA512 {
-				return write!(f, "ECDSA_P521_SHA512");
-			}
-
-			write!(f, "Unknown")
-		}
+		write!(f, "{}", self.name)
 	}
 }
 
@@ -135,6 +106,7 @@ pub(crate) mod algo {
 
 	/// RSA signing with PKCS#1 1.5 padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static RSA_PKCS1_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+		name: "RSA_PKCS1_SHA256",
 		oids_sign_alg: &[RSA_ENCRYPTION],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PKCS1_SHA256),
@@ -145,6 +117,7 @@ pub(crate) mod algo {
 
 	/// RSA signing with PKCS#1 1.5 padding and SHA-384 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static RSA_PKCS1_SHA384: SignatureAlgorithm = SignatureAlgorithm {
+		name: "RSA_PKCS1_SHA384",
 		oids_sign_alg: &[RSA_ENCRYPTION],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PKCS1_SHA384),
@@ -155,6 +128,7 @@ pub(crate) mod algo {
 
 	/// RSA signing with PKCS#1 1.5 padding and SHA-512 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static RSA_PKCS1_SHA512: SignatureAlgorithm = SignatureAlgorithm {
+		name: "RSA_PKCS1_SHA512",
 		oids_sign_alg: &[RSA_ENCRYPTION],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PKCS1_SHA512),
@@ -170,6 +144,7 @@ pub(crate) mod algo {
 	//
 	/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub(crate) static RSA_PSS_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+		name: "RSA_PSS_SHA256",
 		// We could also use RSA_ENCRYPTION here, but it's recommended
 		// to use ID-RSASSA-PSS if possible.
 		oids_sign_alg: &[RSASSA_PSS],
@@ -186,6 +161,7 @@ pub(crate) mod algo {
 
 	/// ECDSA signing using the P-256 curves and SHA-256 hashing as per [RFC 5758](https://tools.ietf.org/html/rfc5758#section-3.2)
 	pub static ECDSA_P256_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ECDSA_P256_SHA256",
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_256_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P256_SHA256_ASN1_SIGNING),
@@ -196,6 +172,7 @@ pub(crate) mod algo {
 
 	/// ECDSA signing using the P-384 curves and SHA-384 hashing as per [RFC 5758](https://tools.ietf.org/html/rfc5758#section-3.2)
 	pub static ECDSA_P384_SHA384: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ECDSA_P384_SHA384",
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_384_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P384_SHA384_ASN1_SIGNING),
@@ -211,6 +188,7 @@ pub(crate) mod algo {
 	/// Only supported with the `aws_lc_rs` backend.
 	#[cfg(feature = "aws_lc_rs")]
 	pub static ECDSA_P521_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ECDSA_P521_SHA256",
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P521_SHA256_ASN1_SIGNING),
@@ -226,6 +204,7 @@ pub(crate) mod algo {
 	/// Only supported with the `aws_lc_rs` backend.
 	#[cfg(feature = "aws_lc_rs")]
 	pub static ECDSA_P521_SHA384: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ECDSA_P521_SHA384",
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P521_SHA384_ASN1_SIGNING),
@@ -239,6 +218,7 @@ pub(crate) mod algo {
 	/// Only supported with the `aws_lc_rs` backend.
 	#[cfg(feature = "aws_lc_rs")]
 	pub static ECDSA_P521_SHA512: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ECDSA_P521_SHA512",
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::EcDsa(&signature::ECDSA_P521_SHA512_ASN1_SIGNING),
@@ -249,6 +229,7 @@ pub(crate) mod algo {
 
 	/// ED25519 curve signing as per [RFC 8410](https://tools.ietf.org/html/rfc8410)
 	pub static ED25519: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ED25519",
 		// id-Ed25519 in RFC 8410
 		oids_sign_alg: &[&[1, 3, 101, 112]],
 		#[cfg(feature = "crypto")]
@@ -261,6 +242,7 @@ pub(crate) mod algo {
 	/// ML-DSA-44 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 	pub static ML_DSA_44: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ML_DSA_44",
 		oids_sign_alg: &[crate::oid::ML_DSA_44],
 		#[cfg(all(feature = "crypto", feature = "aws_lc_rs_unstable"))]
 		sign_alg: SignAlgo::PqDsa(&ML_DSA_44_SIGNING),
@@ -271,6 +253,7 @@ pub(crate) mod algo {
 	/// ML-DSA-44 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 	pub static ML_DSA_65: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ML_DSA_65",
 		oids_sign_alg: &[crate::oid::ML_DSA_65],
 		#[cfg(all(feature = "crypto", feature = "aws_lc_rs_unstable"))]
 		sign_alg: SignAlgo::PqDsa(&ML_DSA_65_SIGNING),
@@ -281,6 +264,7 @@ pub(crate) mod algo {
 	/// ML-DSA-44 signing as per <https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#name-identifiers>.
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 	pub static ML_DSA_87: SignatureAlgorithm = SignatureAlgorithm {
+		name: "ML_DSA_87",
 		oids_sign_alg: &[crate::oid::ML_DSA_87],
 		#[cfg(all(feature = "crypto", feature = "aws_lc_rs_unstable"))]
 		sign_alg: SignAlgo::PqDsa(&ML_DSA_87_SIGNING),

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -208,18 +208,18 @@ pub enum KeyPairAlgorithm {
 impl From<KeyPairAlgorithm> for &'static SignatureAlgorithm {
 	fn from(alg: KeyPairAlgorithm) -> Self {
 		match alg {
-			KeyPairAlgorithm::Rsa => &rcgen::PKCS_RSA_SHA256,
-			KeyPairAlgorithm::Ed25519 => &rcgen::PKCS_ED25519,
-			KeyPairAlgorithm::EcdsaP256 => &rcgen::PKCS_ECDSA_P256_SHA256,
-			KeyPairAlgorithm::EcdsaP384 => &rcgen::PKCS_ECDSA_P384_SHA384,
+			KeyPairAlgorithm::Rsa => &rcgen::RSA_PKCS1_SHA256,
+			KeyPairAlgorithm::Ed25519 => &rcgen::ED25519,
+			KeyPairAlgorithm::EcdsaP256 => &rcgen::ECDSA_P256_SHA256,
+			KeyPairAlgorithm::EcdsaP384 => &rcgen::ECDSA_P384_SHA384,
 			#[cfg(feature = "aws_lc_rs")]
-			KeyPairAlgorithm::EcdsaP521 => &rcgen::PKCS_ECDSA_P521_SHA512,
+			KeyPairAlgorithm::EcdsaP521 => &rcgen::ECDSA_P521_SHA512,
 			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
-			KeyPairAlgorithm::MlDsa44 => &rcgen::PKCS_ML_DSA_44,
+			KeyPairAlgorithm::MlDsa44 => &rcgen::ML_DSA_44,
 			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
-			KeyPairAlgorithm::MlDsa65 => &rcgen::PKCS_ML_DSA_65,
+			KeyPairAlgorithm::MlDsa65 => &rcgen::ML_DSA_65,
 			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
-			KeyPairAlgorithm::MlDsa87 => &rcgen::PKCS_ML_DSA_87,
+			KeyPairAlgorithm::MlDsa87 => &rcgen::ML_DSA_87,
 		}
 	}
 }
@@ -476,25 +476,16 @@ mod tests {
 	#[test]
 	fn key_pair_algorithm_to_keypair() -> anyhow::Result<()> {
 		let keypair = KeyPair::generate_for(KeyPairAlgorithm::Ed25519.into())?;
-		assert_eq!(format!("{:?}", keypair.algorithm()), "PKCS_ED25519");
+		assert_eq!(format!("{:?}", keypair.algorithm()), "ED25519");
 		let keypair = KeyPair::generate_for(KeyPairAlgorithm::EcdsaP256.into())?;
-		assert_eq!(
-			format!("{:?}", keypair.algorithm()),
-			"PKCS_ECDSA_P256_SHA256"
-		);
+		assert_eq!(format!("{:?}", keypair.algorithm()), "ECDSA_P256_SHA256");
 		let keypair = KeyPair::generate_for(KeyPairAlgorithm::EcdsaP384.into())?;
-		assert_eq!(
-			format!("{:?}", keypair.algorithm()),
-			"PKCS_ECDSA_P384_SHA384"
-		);
+		assert_eq!(format!("{:?}", keypair.algorithm()), "ECDSA_P384_SHA384");
 
 		#[cfg(feature = "aws_lc_rs")]
 		{
 			let keypair = KeyPair::generate_for(KeyPairAlgorithm::EcdsaP521.into())?;
-			assert_eq!(
-				format!("{:?}", keypair.algorithm()),
-				"PKCS_ECDSA_P521_SHA512"
-			);
+			assert_eq!(format!("{:?}", keypair.algorithm()), "ECDSA_P521_SHA512");
 		}
 		Ok(())
 	}

--- a/verify-tests/tests/botan.rs
+++ b/verify-tests/tests/botan.rs
@@ -57,7 +57,7 @@ fn test_botan() {
 #[test]
 fn test_botan_256() {
 	let (params, _) = default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P256_SHA256).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -67,7 +67,7 @@ fn test_botan_256() {
 #[test]
 fn test_botan_384() {
 	let (params, _) = default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P384_SHA384).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -78,7 +78,7 @@ fn test_botan_384() {
 #[cfg(feature = "aws_lc_rs")]
 fn test_botan_521() {
 	let (params, _) = default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P521_SHA512).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P521_SHA512).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -88,7 +88,7 @@ fn test_botan_521() {
 #[test]
 fn test_botan_25519() {
 	let (params, _) = default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ED25519).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -201,7 +201,7 @@ fn test_botan_imported_ca_with_printable_string() {
 #[test]
 fn test_botan_crl_parse() {
 	// Create an issuer CA.
-	let alg = &rcgen::PKCS_ECDSA_P256_SHA256;
+	let alg = &rcgen::ECDSA_P256_SHA256;
 	let (mut issuer, _) = util::default_params();
 	issuer.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
 	issuer.key_usages = vec![

--- a/verify-tests/tests/generic.rs
+++ b/verify-tests/tests/generic.rs
@@ -12,16 +12,16 @@ mod test_key_params_mismatch {
 	#[test]
 	fn test_key_params_mismatch() {
 		let available_key_params = [
-			&rcgen::PKCS_RSA_SHA256,
-			&rcgen::PKCS_ECDSA_P256_SHA256,
-			&rcgen::PKCS_ECDSA_P384_SHA384,
+			&rcgen::RSA_PKCS1_SHA256,
+			&rcgen::ECDSA_P256_SHA256,
+			&rcgen::ECDSA_P384_SHA384,
 			#[cfg(feature = "aws_lc_rs")]
-			&rcgen::PKCS_ECDSA_P521_SHA256,
+			&rcgen::ECDSA_P521_SHA256,
 			#[cfg(feature = "aws_lc_rs")]
-			&rcgen::PKCS_ECDSA_P521_SHA384,
+			&rcgen::ECDSA_P521_SHA384,
 			#[cfg(feature = "aws_lc_rs")]
-			&rcgen::PKCS_ECDSA_P521_SHA512,
-			&rcgen::PKCS_ED25519,
+			&rcgen::ECDSA_P521_SHA512,
+			&rcgen::ED25519,
 		];
 		for (i, kalg_1) in available_key_params.iter().enumerate() {
 			for (j, kalg_2) in available_key_params.iter().enumerate() {
@@ -33,7 +33,7 @@ mod test_key_params_mismatch {
 
 				assert_ne!(*kalg_1, *kalg_2);
 				let names = [format!("{kalg_1:?}"), format!("{kalg_2:?}")];
-				if names.into_iter().all(|n| n.starts_with("PKCS_ECDSA_P521")) {
+				if names.into_iter().all(|n| n.starts_with("ECDSA_P521")) {
 					continue;
 				}
 

--- a/verify-tests/tests/openssl.rs
+++ b/verify-tests/tests/openssl.rs
@@ -190,7 +190,7 @@ fn test_request() {
 #[test]
 fn test_openssl_256() {
 	let (params, _) = util::default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P256_SHA256).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -201,7 +201,7 @@ fn test_openssl_256() {
 #[test]
 fn test_openssl_384() {
 	let (params, _) = util::default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P384_SHA384).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -213,7 +213,7 @@ fn test_openssl_384() {
 #[cfg(feature = "aws_lc_rs")]
 fn test_openssl_521() {
 	let (params, _) = util::default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P521_SHA512).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P521_SHA512).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -224,7 +224,7 @@ fn test_openssl_521() {
 #[test]
 fn test_openssl_25519() {
 	let (params, _) = util::default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ED25519).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -281,9 +281,9 @@ fn test_openssl_rsa_given() {
 #[test]
 fn test_openssl_rsa_combinations_given() {
 	let alg_list = [
-		&rcgen::PKCS_RSA_SHA256,
-		&rcgen::PKCS_RSA_SHA384,
-		&rcgen::PKCS_RSA_SHA512,
+		&rcgen::RSA_PKCS1_SHA256,
+		&rcgen::RSA_PKCS1_SHA384,
+		&rcgen::RSA_PKCS1_SHA512,
 		//&rcgen::PKCS_RSA_PSS_SHA256,
 	];
 	for (i, alg) in alg_list.iter().enumerate() {
@@ -355,7 +355,7 @@ fn test_openssl_separate_ca_with_printable_string() {
 fn test_openssl_separate_ca_with_other_signing_alg() {
 	let (mut ca_params, _) = util::default_params();
 	ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-	let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let ca_key = KeyPair::generate_for(&rcgen::ECDSA_P256_SHA256).unwrap();
 	let ca_cert = ca_params.self_signed(&ca_key).unwrap();
 	let ca = Issuer::new(ca_params, ca_key);
 
@@ -366,7 +366,7 @@ fn test_openssl_separate_ca_with_other_signing_alg() {
 	params
 		.distinguished_name
 		.push(DnType::CommonName, "Dev domain");
-	let cert_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
+	let cert_key = KeyPair::generate_for(&rcgen::ECDSA_P384_SHA384).unwrap();
 	let cert = params.signed_by(&cert_key, &ca).unwrap();
 	let key = cert_key.serialize_der();
 

--- a/verify-tests/tests/webpki.rs
+++ b/verify-tests/tests/webpki.rs
@@ -137,7 +137,7 @@ fn test_webpki() {
 #[test]
 fn test_webpki_256() {
 	let (params, _) = util::default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P256_SHA256).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -154,7 +154,7 @@ fn test_webpki_256() {
 #[test]
 fn test_webpki_384() {
 	let (params, _) = util::default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P384_SHA384).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -171,7 +171,7 @@ fn test_webpki_384() {
 #[test]
 fn test_webpki_25519() {
 	let (params, _) = util::default_params();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ED25519).unwrap();
 	let cert = params.self_signed(&key_pair).unwrap();
 
 	// Now verify the certificate.
@@ -256,17 +256,17 @@ const ML_DSA_ALGS: &[(
 	&PqdsaSigningAlgorithm,
 )] = &[
 	(
-		&rcgen::PKCS_ML_DSA_44,
+		&rcgen::ML_DSA_44,
 		webpki::aws_lc_rs::ML_DSA_44,
 		&ML_DSA_44_SIGNING,
 	),
 	(
-		&rcgen::PKCS_ML_DSA_65,
+		&rcgen::ML_DSA_65,
 		webpki::aws_lc_rs::ML_DSA_65,
 		&ML_DSA_65_SIGNING,
 	),
 	(
-		&rcgen::PKCS_ML_DSA_87,
+		&rcgen::ML_DSA_87,
 		webpki::aws_lc_rs::ML_DSA_87,
 		&ML_DSA_87_SIGNING,
 	),
@@ -277,17 +277,17 @@ const ML_DSA_ALGS: &[(
 fn test_webpki_rsa_combinations_given() {
 	let configs: &[(_, _, &'static dyn signature::RsaEncoding)] = &[
 		(
-			&rcgen::PKCS_RSA_SHA256,
+			&rcgen::RSA_PKCS1_SHA256,
 			webpki::ring::RSA_PKCS1_2048_8192_SHA256,
 			&signature::RSA_PKCS1_SHA256,
 		),
 		(
-			&rcgen::PKCS_RSA_SHA384,
+			&rcgen::RSA_PKCS1_SHA384,
 			webpki::ring::RSA_PKCS1_2048_8192_SHA384,
 			&signature::RSA_PKCS1_SHA384,
 		),
 		(
-			&rcgen::PKCS_RSA_SHA512,
+			&rcgen::RSA_PKCS1_SHA512,
 			webpki::ring::RSA_PKCS1_2048_8192_SHA512,
 			&signature::RSA_PKCS1_SHA512,
 		),
@@ -338,7 +338,7 @@ fn test_webpki_separate_ca() {
 fn test_webpki_separate_ca_with_other_signing_alg() {
 	let (mut ca_params, _) = util::default_params();
 	ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-	let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let ca_key = KeyPair::generate_for(&rcgen::ECDSA_P256_SHA256).unwrap();
 	let ca_cert = ca_params.self_signed(&ca_key).unwrap();
 
 	let mut params = CertificateParams::new(vec!["crabs.crabs".to_string()]).unwrap();
@@ -349,7 +349,7 @@ fn test_webpki_separate_ca_with_other_signing_alg() {
 		.distinguished_name
 		.push(DnType::CommonName, "Dev domain");
 
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ED25519).unwrap();
 	let ca = Issuer::new(ca_params, ca_key);
 	let cert = params.signed_by(&key_pair, &ca).unwrap();
 	check_cert_ca(
@@ -382,12 +382,12 @@ fn from_remote() {
 		}
 
 		fn algorithm(&self) -> &'static rcgen::SignatureAlgorithm {
-			&rcgen::PKCS_ECDSA_P256_SHA256
+			&rcgen::ECDSA_P256_SHA256
 		}
 	}
 
 	let rng = ring::rand::SystemRandom::new();
-	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let key_pair = KeyPair::generate_for(&rcgen::ECDSA_P256_SHA256).unwrap();
 	let remote = EcdsaKeyPair::from_pkcs8(
 		&signature::ECDSA_P256_SHA256_ASN1_SIGNING,
 		&key_pair.serialize_der(),
@@ -650,7 +650,7 @@ fn test_webpki_crl_parse() {
 #[test]
 fn test_webpki_crl_revoke() {
 	// Create an issuer CA.
-	let alg = &rcgen::PKCS_ECDSA_P256_SHA256;
+	let alg = &rcgen::ECDSA_P256_SHA256;
 	let (mut issuer, _) = util::default_params();
 	issuer.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
 	issuer.key_usages = vec![


### PR DESCRIPTION
Just noticed some of these bits, not fixing a specific issue.

I also noticed that there's a lot of RSA-PSS-related things that are commented out. I've left that alone but it probably deserves some attention for someone who knows the background?