### PR TITLE
Added support for RSASSA-PSS padding algorithms

### DIFF
--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -259,12 +259,18 @@ impl KeyPair {
 		} else if alg == &PKCS_RSA_SHA512 {
 			let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
 			KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA512)
-		} else if alg == &PKCS_RSA_PSS_SHA256 {
-			let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
-			KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA256)
 		} else {
 			#[cfg(feature = "aws_lc_rs")]
-			if alg == &PKCS_ECDSA_P521_SHA256 {
+			if alg == &PKCS_RSA_PSS_SHA256 {
+				let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
+				KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA256)
+			} else if alg == &PKCS_RSA_PSS_SHA384 {
+				let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
+				KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA384)
+			} else if alg == &PKCS_RSA_PSS_SHA512 {
+				let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
+				KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA512)
+			} else if alg == &PKCS_ECDSA_P521_SHA256 {
 				KeyPairKind::Ec(ecdsa_from_pkcs8(
 					&signature::ECDSA_P521_SHA256_ASN1_SIGNING,
 					&serialized_der,

--- a/rcgen/src/oid.rs
+++ b/rcgen/src/oid.rs
@@ -35,6 +35,7 @@ pub(crate) const ML_DSA_87: &[u64] = &[2, 16, 840, 1, 101, 3, 4, 3, 19];
 /// rsaEncryption in [RFC 4055](https://www.rfc-editor.org/rfc/rfc4055#section-6)
 pub(crate) const RSA_ENCRYPTION: &[u64] = &[1, 2, 840, 113549, 1, 1, 1];
 
+#[cfg(feature = "aws_lc_rs")]
 /// id-RSASSA-PSS in [RFC 4055](https://www.rfc-editor.org/rfc/rfc4055#section-6)
 pub(crate) const RSASSA_PSS: &[u64] = &[1, 2, 840, 113549, 1, 1, 10];
 

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -95,14 +95,20 @@ impl fmt::Debug for SignatureAlgorithm {
 impl PartialEq for SignatureAlgorithm {
 	fn eq(&self, other: &Self) -> bool {
 		// RSA-PSS algs all have the same OID with different `params` fields
-		if let SignatureAlgorithmParams::RsaPss{hash_algorithm: selfhash, ..} = self.params {
-			if let SignatureAlgorithmParams::RsaPss{hash_algorithm: otherhash, ..} = other.params {
-				return (self.oids_sign_alg, self.oid_components, selfhash) ==
-					(other.oids_sign_alg, other.oid_components, otherhash)
-			}
+		if let SignatureAlgorithmParams::RsaPss {
+			hash_algorithm: selfhash,
+			..
+		} = self.params
+		{
+			if let SignatureAlgorithmParams::RsaPss {
+				hash_algorithm: otherhash,
+				..
+			} = other.params
+			{
+				return (self.oids_sign_alg, self.oid_components, selfhash)
+					== (other.oids_sign_alg, other.oid_components, otherhash);
 		}
-		(self.oids_sign_alg, self.oid_components) == 
-			(other.oids_sign_alg, other.oid_components)
+		(self.oids_sign_alg, self.oid_components) == (other.oids_sign_alg, other.oid_components)
 	}
 }
 

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -56,6 +56,10 @@ impl fmt::Debug for SignatureAlgorithm {
 			write!(f, "PKCS_RSA_SHA512")
 		} else if self == &PKCS_RSA_PSS_SHA256 {
 			write!(f, "PKCS_RSA_PSS_SHA256")
+		} else if self == &PKCS_RSA_PSS_SHA384 {
+			write!(f, "PKCS_RSA_PSS_SHA384")
+		} else if self == &PKCS_RSA_PSS_SHA512 {
+			write!(f, "PKCS_RSA_PSS_SHA512")
 		} else if self == &PKCS_ECDSA_P256_SHA256 {
 			write!(f, "PKCS_ECDSA_P256_SHA256")
 		} else if self == &PKCS_ECDSA_P384_SHA384 {
@@ -103,7 +107,9 @@ impl SignatureAlgorithm {
 			&PKCS_RSA_SHA256,
 			&PKCS_RSA_SHA384,
 			&PKCS_RSA_SHA512,
-			//&PKCS_RSA_PSS_SHA256,
+			&PKCS_RSA_PSS_SHA256,
+			&PKCS_RSA_PSS_SHA384,
+			&PKCS_RSA_PSS_SHA512,
 			&PKCS_ECDSA_P256_SHA256,
 			&PKCS_ECDSA_P384_SHA384,
 			#[cfg(feature = "aws_lc_rs")]
@@ -163,13 +169,8 @@ pub(crate) mod algo {
 		params: SignatureAlgorithmParams::Null,
 	};
 
-	// TODO: not really sure whether the certs we generate actually work.
-	// Both openssl and webpki reject them. It *might* be possible that openssl
-	// accepts the certificate if the key is a proper RSA-PSS key, but ring doesn't
-	// support those: https://github.com/briansmith/ring/issues/1353
-	//
 	/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
-	pub(crate) static PKCS_RSA_PSS_SHA256: SignatureAlgorithm = SignatureAlgorithm {
+	pub static PKCS_RSA_PSS_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		// We could also use RSA_ENCRYPTION here, but it's recommended
 		// to use ID-RSASSA-PSS if possible.
 		oids_sign_alg: &[RSASSA_PSS],
@@ -180,7 +181,40 @@ pub(crate) mod algo {
 		params: SignatureAlgorithmParams::RsaPss {
 			// id-sha256 in https://datatracker.ietf.org/doc/html/rfc4055#section-2.1
 			hash_algorithm: &[2, 16, 840, 1, 101, 3, 4, 2, 1],
-			salt_length: 20,
+			// Salt length = hash octets (RFC 4055, pg. 9)
+			salt_length: 32,
+		},
+	};
+
+	/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-384 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
+	pub static PKCS_RSA_PSS_SHA384: SignatureAlgorithm = SignatureAlgorithm {
+		// We could also use RSA_ENCRYPTION here, but it's recommended
+		// to use ID-RSASSA-PSS if possible.
+		oids_sign_alg: &[RSASSA_PSS],
+		#[cfg(feature = "crypto")]
+		sign_alg: SignAlgo::Rsa(&signature::RSA_PSS_SHA384),
+		oid_components: RSASSA_PSS, //&[1, 2, 840, 113549, 1, 1, 13],
+		params: SignatureAlgorithmParams::RsaPss {
+			// id-sha256 in https://datatracker.ietf.org/doc/html/rfc4055#section-2.1
+			hash_algorithm: &[2, 16, 840, 1, 101, 3, 4, 2, 2],
+			// Salt length = hash octets (RFC 4055, pg. 9)
+			salt_length: 48,
+		},
+	};
+
+	/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-512 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
+	pub static PKCS_RSA_PSS_SHA512: SignatureAlgorithm = SignatureAlgorithm {
+		// We could also use RSA_ENCRYPTION here, but it's recommended
+		// to use ID-RSASSA-PSS if possible.
+		oids_sign_alg: &[RSASSA_PSS],
+		#[cfg(feature = "crypto")]
+		sign_alg: SignAlgo::Rsa(&signature::RSA_PSS_SHA512),
+		oid_components: RSASSA_PSS, //&[1, 2, 840, 113549, 1, 1, 13],
+		params: SignatureAlgorithmParams::RsaPss {
+			// id-sha256 in https://datatracker.ietf.org/doc/html/rfc4055#section-2.1
+			hash_algorithm: &[2, 16, 840, 1, 101, 3, 4, 2, 3],
+			// Salt length = hash octets (RFC 4055, pg. 9)
+			salt_length: 64,
 		},
 	};
 

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -29,6 +29,7 @@ pub(crate) enum SignatureAlgorithmParams {
 	/// Write null parameters
 	Null,
 	/// RSASSA-PSS-params as per RFC 4055
+	#[allow(unused)] // RsaPss only used by feature `aws_lc_rs`
 	RsaPss {
 		hash_algorithm: &'static [u64],
 		salt_length: u64,
@@ -54,12 +55,6 @@ impl fmt::Debug for SignatureAlgorithm {
 			write!(f, "PKCS_RSA_SHA384")
 		} else if self == &PKCS_RSA_SHA512 {
 			write!(f, "PKCS_RSA_SHA512")
-		} else if self == &PKCS_RSA_PSS_SHA256 {
-			write!(f, "PKCS_RSA_PSS_SHA256")
-		} else if self == &PKCS_RSA_PSS_SHA384 {
-			write!(f, "PKCS_RSA_PSS_SHA384")
-		} else if self == &PKCS_RSA_PSS_SHA512 {
-			write!(f, "PKCS_RSA_PSS_SHA512")
 		} else if self == &PKCS_ECDSA_P256_SHA256 {
 			write!(f, "PKCS_ECDSA_P256_SHA256")
 		} else if self == &PKCS_ECDSA_P384_SHA384 {
@@ -67,6 +62,18 @@ impl fmt::Debug for SignatureAlgorithm {
 		} else if self == &PKCS_ED25519 {
 			write!(f, "PKCS_ED25519")
 		} else {
+			#[cfg(feature = "aws_lc_rs")]
+			if self == &PKCS_RSA_PSS_SHA256 {
+				return write!(f, "PKCS_RSA_PSS_SHA256");
+			}
+			#[cfg(feature = "aws_lc_rs")]
+			if self == &PKCS_RSA_PSS_SHA384 {
+				return write!(f, "PKCS_RSA_PSS_SHA384");
+			}
+			#[cfg(feature = "aws_lc_rs")]
+			if self == &PKCS_RSA_PSS_SHA512 {
+				return write!(f, "PKCS_RSA_PSS_SHA512");
+			}
 			#[cfg(feature = "aws_lc_rs")]
 			if self == &PKCS_ECDSA_P521_SHA256 {
 				return write!(f, "PKCS_ECDSA_P521_SHA256");
@@ -87,7 +94,15 @@ impl fmt::Debug for SignatureAlgorithm {
 
 impl PartialEq for SignatureAlgorithm {
 	fn eq(&self, other: &Self) -> bool {
-		(self.oids_sign_alg, self.oid_components) == (other.oids_sign_alg, other.oid_components)
+		// RSA-PSS algs all have the same OID with different `params` fields
+		if let SignatureAlgorithmParams::RsaPss{hash_algorithm: selfhash, ..} = self.params {
+			if let SignatureAlgorithmParams::RsaPss{hash_algorithm: otherhash, ..} = other.params {
+				return (self.oids_sign_alg, self.oid_components, selfhash) ==
+					(other.oids_sign_alg, other.oid_components, otherhash)
+			}
+		}
+		(self.oids_sign_alg, self.oid_components) == 
+			(other.oids_sign_alg, other.oid_components)
 	}
 }
 
@@ -107,8 +122,11 @@ impl SignatureAlgorithm {
 			&PKCS_RSA_SHA256,
 			&PKCS_RSA_SHA384,
 			&PKCS_RSA_SHA512,
+			#[cfg(feature = "aws_lc_rs")]
 			&PKCS_RSA_PSS_SHA256,
+			#[cfg(feature = "aws_lc_rs")]
 			&PKCS_RSA_PSS_SHA384,
+			#[cfg(feature = "aws_lc_rs")]
 			&PKCS_RSA_PSS_SHA512,
 			&PKCS_ECDSA_P256_SHA256,
 			&PKCS_ECDSA_P384_SHA384,
@@ -169,6 +187,7 @@ pub(crate) mod algo {
 		params: SignatureAlgorithmParams::Null,
 	};
 
+	#[cfg(feature = "aws_lc_rs")]
 	/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static PKCS_RSA_PSS_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		// We could also use RSA_ENCRYPTION here, but it's recommended
@@ -176,6 +195,7 @@ pub(crate) mod algo {
 		oids_sign_alg: &[RSASSA_PSS],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PSS_SHA256),
+		// rSASSA-PSS-SHA256-Identifier
 		oid_components: RSASSA_PSS, //&[1, 2, 840, 113549, 1, 1, 13],
 		// rSASSA-PSS-SHA256-Params in RFC 4055
 		params: SignatureAlgorithmParams::RsaPss {
@@ -186,10 +206,9 @@ pub(crate) mod algo {
 		},
 	};
 
+	#[cfg(feature = "aws_lc_rs")]
 	/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-384 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static PKCS_RSA_PSS_SHA384: SignatureAlgorithm = SignatureAlgorithm {
-		// We could also use RSA_ENCRYPTION here, but it's recommended
-		// to use ID-RSASSA-PSS if possible.
 		oids_sign_alg: &[RSASSA_PSS],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PSS_SHA384),
@@ -202,10 +221,9 @@ pub(crate) mod algo {
 		},
 	};
 
+	#[cfg(feature = "aws_lc_rs")]
 	/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-512 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
 	pub static PKCS_RSA_PSS_SHA512: SignatureAlgorithm = SignatureAlgorithm {
-		// We could also use RSA_ENCRYPTION here, but it's recommended
-		// to use ID-RSASSA-PSS if possible.
 		oids_sign_alg: &[RSASSA_PSS],
 		#[cfg(feature = "crypto")]
 		sign_alg: SignAlgo::Rsa(&signature::RSA_PSS_SHA512),

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -107,6 +107,7 @@ impl PartialEq for SignatureAlgorithm {
 			{
 				return (self.oids_sign_alg, self.oid_components, selfhash)
 					== (other.oids_sign_alg, other.oid_components, otherhash);
+			}
 		}
 		(self.oids_sign_alg, self.oid_components) == (other.oids_sign_alg, other.oid_components)
 	}

--- a/verify-tests/tests/openssl.rs
+++ b/verify-tests/tests/openssl.rs
@@ -187,6 +187,7 @@ fn test_request() {
 	verify_csr(&params, &key_pair);
 }
 
+#[cfg(feature = "aws_lc_rs")]
 #[test]
 fn test_openssl_rsa_pss_sha256() {
 	let (params, _) = util::default_params();
@@ -198,6 +199,7 @@ fn test_openssl_rsa_pss_sha256() {
 	verify_csr(&params, &key_pair);
 }
 
+#[cfg(feature = "aws_lc_rs")]
 #[test]
 fn test_openssl_rsa_pss_sha384() {
 	let (params, _) = util::default_params();
@@ -209,6 +211,7 @@ fn test_openssl_rsa_pss_sha384() {
 	verify_csr(&params, &key_pair);
 }
 
+#[cfg(feature = "aws_lc_rs")]
 #[test]
 fn test_openssl_rsa_pss_sha512() {
 	let (params, _) = util::default_params();

--- a/verify-tests/tests/openssl.rs
+++ b/verify-tests/tests/openssl.rs
@@ -188,6 +188,39 @@ fn test_request() {
 }
 
 #[test]
+fn test_openssl_rsa_pss_sha256() {
+	let (params, _) = util::default_params();
+	let key_pair = KeyPair::generate_for(&rcgen::PKCS_RSA_PSS_SHA256).unwrap();
+	let cert = params.self_signed(&key_pair).unwrap();
+
+	// Now verify the certificate.
+	verify_cert(&cert, &key_pair);
+	verify_csr(&params, &key_pair);
+}
+
+#[test]
+fn test_openssl_rsa_pss_sha384() {
+	let (params, _) = util::default_params();
+	let key_pair = KeyPair::generate_for(&rcgen::PKCS_RSA_PSS_SHA384).unwrap();
+	let cert = params.self_signed(&key_pair).unwrap();
+
+	// Now verify the certificate.
+	verify_cert(&cert, &key_pair);
+	verify_csr(&params, &key_pair);
+}
+
+#[test]
+fn test_openssl_rsa_pss_sha512() {
+	let (params, _) = util::default_params();
+	let key_pair = KeyPair::generate_for(&rcgen::PKCS_RSA_PSS_SHA512).unwrap();
+	let cert = params.self_signed(&key_pair).unwrap();
+
+	// Now verify the certificate.
+	verify_cert(&cert, &key_pair);
+	verify_csr(&params, &key_pair);
+}
+
+#[test]
 fn test_openssl_256() {
 	let (params, _) = util::default_params();
 	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();


### PR DESCRIPTION
Added algorithms to `sign_algo.rs` `PKCS_RSA_PSS_SHA256`, `PKCS_RSA_PSS_SHA384`, and `PKCS_RSA_PSS_SHA512`. 

A half implemented version of `PKCS_RSA_PSS_SHA256` already existed with a comment saying this doesn't work because `ring` hasn't implemented PSS padding ([here](https://github.com/briansmith/ring/issues/1353)). It seems that since then it has ([here](https://github.com/briansmith/ring/blame/main/src/rsa/padding/pss.rs)), and that comment was made before the release of `aws-lc-rs`.

There was also an issue in the pre-existing `PKCS_RSA_PSS_SHA256` function in which the salt length was set to the default 20 instead of the recommended value of the number of octets of the hash algorithm ([RFC 4055](https://datatracker.ietf.org/doc/html/rfc4055#section-3.1), pg. 9).

This is an important change as, if I am reading it correctly, non-PSS padding has been deprecated since [RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446#section-4.4.3) (pg. 70), with security concerns like [ROBOT](https://robotattack.org/).

I was able to successfully create CSRs using all three of these algorithms using the `aws-lc-rs` backend. However, I'm not familiar with the unit testing of this library and I am new to contributions, so I would appreciate an independant review of these additions before they are merged.

Thank you for your time,
MC