### PR TITLE
Add support for serializing BasicConstraints in CSR's

### DIFF
--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -200,6 +200,8 @@ impl CertificateParams {
 					// Write subject_alt_names
 					self.write_subject_alt_names(writer.next());
 					self.write_extended_key_usage(writer.next());
+					// Write is_ca
+					self.write_is_ca(writer.next());
 
 					// Write custom extensions
 					for ext in &self.custom_extensions {
@@ -370,7 +372,6 @@ impl CertificateParams {
 			extended_key_usages,
 		);
 		if serial_number.is_some()
-			|| *is_ca != IsCa::NoCa
 			|| name_constraints.is_some()
 			|| !crl_distribution_points.is_empty()
 			|| *use_authority_key_identifier_extension
@@ -382,7 +383,8 @@ impl CertificateParams {
 		let write_extension_request = !key_usages.is_empty()
 			|| !subject_alt_names.is_empty()
 			|| !extended_key_usages.is_empty()
-			|| !custom_extensions.is_empty();
+			|| !custom_extensions.is_empty()
+			|| matches!(is_ca, IsCa::ExplicitNoCa | IsCa::Ca(_));
 
 		let der = sign_der(subject_key, |writer| {
 			// Write version

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -251,6 +251,25 @@ impl CertificateParams {
 		}
 	}
 
+	/// Write a certificate's BasicConstraints as defined in RFC 5280.
+	fn write_is_ca(&self, writer: DERWriter) {
+		let is_ca = match &self.is_ca {
+			IsCa::Ca(bc) => Some(bc),
+			IsCa::ExplicitNoCa => None,
+			IsCa::NoCa => return,
+		};
+
+		// Write basic_constraints
+		write_x509_extension(writer, oid::BASIC_CONSTRAINTS, true, |writer| {
+			writer.write_sequence(|writer| {
+				writer.next().write_bool(is_ca.is_some()); // cA flag
+				if let Some(BasicConstraints::Constrained(path_len_constraint)) = is_ca {
+					writer.next().write_u8(*path_len_constraint); // pathLenConstraint integer
+				}
+			});
+		});
+	}
+
 	fn write_subject_alt_names(&self, writer: DERWriter) {
 		if self.subject_alt_names.is_empty() {
 			return;

--- a/rcgen/src/csr.rs
+++ b/rcgen/src/csr.rs
@@ -212,7 +212,10 @@ mod tests {
 	use x509_parser::certification_request::X509CertificationRequest;
 	use x509_parser::prelude::{FromDer, ParsedExtension};
 
-	use crate::{CertificateParams, ExtendedKeyUsagePurpose, KeyPair, KeyUsagePurpose};
+	use crate::{
+		BasicConstraints, CertificateParams, CertificateSigningRequestParams,
+		ExtendedKeyUsagePurpose, IsCa, KeyPair, KeyUsagePurpose,
+	};
 
 	#[test]
 	fn dont_write_sans_extension_if_no_sans_are_present() {
@@ -244,5 +247,43 @@ mod tests {
 			requested_extensions.first().unwrap(),
 			ParsedExtension::ExtendedKeyUsage(_)
 		));
+	}
+
+	#[test]
+	fn write_basic_constraints_if_present() {
+		use x509_parser::extensions::BasicConstraints as B;
+
+		let params = CertificateParams {
+			is_ca: IsCa::ExplicitNoCa,
+			..Default::default()
+		};
+		let key_pair = KeyPair::generate().unwrap();
+		let csr = params.serialize_request(&key_pair).unwrap();
+		let (_, parsed_csr) = X509CertificationRequest::from_der(csr.der()).unwrap();
+		let requested_extensions = parsed_csr
+			.requested_extensions()
+			.unwrap()
+			.collect::<Vec<_>>();
+
+		assert!(matches!(
+			requested_extensions.first().unwrap(),
+			ParsedExtension::BasicConstraints(B {
+				ca: false,
+				path_len_constraint: None
+			})
+		));
+	}
+
+	#[test]
+	fn serialize_and_deserialize_eq_basic_constraints() {
+		let params = CertificateParams {
+			is_ca: IsCa::Ca(BasicConstraints::Constrained(10)),
+			..Default::default()
+		};
+		let key_pair = KeyPair::generate().unwrap();
+		let csr = params.serialize_request(&key_pair).unwrap();
+		let csr_de = CertificateSigningRequestParams::from_der(csr.der()).unwrap();
+
+		assert_eq!(csr_de.params.is_ca, params.is_ca);
 	}
 }


### PR DESCRIPTION
Add support for BasicConstraints in CSR serializing.

Allows us to now both serialize (this) and deserialize (#420) BasicConstraints in CSR's.

Done so we can cover loading and storing CSR's with a BaiscConstraint attribute.