### PR TITLE
Allow depending on aws-lc-rs fips without pulling in non-fips

### DIFF
--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -12,11 +12,14 @@ keywords.workspace = true
 
 [features]
 default = ["crypto", "pem", "ring"]
-aws_lc_rs = ["crypto", "dep:aws-lc-rs", "aws-lc-rs/aws-lc-sys", "x509-parser?/verify-aws"]
-aws_lc_rs_unstable = ["aws_lc_rs", "aws-lc-rs/unstable", "x509-parser?/verify-aws"]
-fips = ["crypto", "dep:aws-lc-rs", "aws-lc-rs/fips"]
+aws_lc_rs = ["_aws_lc_like", "aws-lc-rs/aws-lc-sys"]
+aws_lc_rs_unstable = ["aws_lc_rs", "aws-lc-rs/unstable"]
+fips = ["_aws_lc_like", "aws-lc-rs/fips"]
 crypto = []
 ring = ["crypto", "dep:ring", "x509-parser?/verify"]
+# Internal feature: enabled automatically whenever `aws_lc_rs` or `fips` is on.
+# Do not enable directly; use `aws_lc_rs` or `fips` instead.
+_aws_lc_like = ["crypto", "dep:aws-lc-rs", "x509-parser?/verify-aws"]
 
 [dependencies]
 aws-lc-rs = { workspace = true, optional = true }

--- a/rcgen/src/key_pair.rs
+++ b/rcgen/src/key_pair.rs
@@ -11,9 +11,9 @@ use yasna::{DERWriter, DERWriterSeq};
 
 #[cfg(any(feature = "crypto", feature = "pem"))]
 use crate::error::ExternalError;
-#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+#[cfg(all(feature = "crypto", feature = "_aws_lc_like"))]
 use crate::ring_like::ecdsa_from_private_key_der;
-#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+#[cfg(all(feature = "crypto", feature = "_aws_lc_like"))]
 use crate::ring_like::rsa::KeySize;
 #[cfg(feature = "crypto")]
 use crate::ring_like::{
@@ -130,12 +130,12 @@ impl KeyPair {
 					serialized_der: key_pair_serialized,
 				})
 			},
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			SignAlgo::Rsa(sign_alg) => Self::generate_rsa_inner(alg, sign_alg, KeySize::Rsa2048),
 			// Ring doesn't have RSA key generation yet:
 			// https://github.com/briansmith/ring/issues/219
 			// https://github.com/briansmith/ring/pull/733
-			#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
+			#[cfg(all(feature = "ring", not(feature = "_aws_lc_like")))]
 			SignAlgo::Rsa(_sign_alg) => Err(Error::KeyGenerationUnavailable),
 		}
 	}
@@ -144,7 +144,7 @@ impl KeyPair {
 	///
 	/// If passed a signature algorithm that is not RSA, it will return
 	/// [`Error::KeyGenerationUnavailable`].
-	#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+	#[cfg(all(feature = "crypto", feature = "_aws_lc_like"))]
 	pub fn generate_rsa_for(
 		alg: &'static SignatureAlgorithm,
 		key_size: RsaKeySize,
@@ -162,7 +162,7 @@ impl KeyPair {
 		}
 	}
 
-	#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+	#[cfg(all(feature = "crypto", feature = "_aws_lc_like"))]
 	fn generate_rsa_inner(
 		alg: &'static SignatureAlgorithm,
 		sign_alg: &'static dyn RsaEncoding,
@@ -263,7 +263,7 @@ impl KeyPair {
 			let rsakp = RsaKeyPair::from_pkcs8(&serialized_der)._err()?;
 			KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA256)
 		} else {
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			if alg == &PKCS_ECDSA_P521_SHA256 {
 				KeyPairKind::Ec(ecdsa_from_pkcs8(
 					&signature::ECDSA_P521_SHA256_ASN1_SIGNING,
@@ -286,7 +286,7 @@ impl KeyPair {
 				panic!("Unknown SignatureAlgorithm specified!");
 			}
 
-			#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
+			#[cfg(all(feature = "ring", not(feature = "_aws_lc_like")))]
 			panic!("Unknown SignatureAlgorithm specified!");
 		};
 
@@ -340,7 +340,7 @@ impl KeyPair {
 		key: &PrivateKeyDer<'_>,
 		alg: &'static SignatureAlgorithm,
 	) -> Result<Self, Error> {
-		#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
+		#[cfg(all(feature = "ring", not(feature = "_aws_lc_like")))]
 		{
 			if let PrivateKeyDer::Pkcs8(key) = key {
 				Self::from_pkcs8_der_and_sign_algo(key, alg)
@@ -348,7 +348,7 @@ impl KeyPair {
 				Err(Error::CouldNotParseKeyPair)
 			}
 		}
-		#[cfg(feature = "aws_lc_rs")]
+		#[cfg(feature = "_aws_lc_like")]
 		{
 			let is_pkcs8 = matches!(key, PrivateKeyDer::Pkcs8(_));
 
@@ -534,7 +534,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for KeyPair {
 	type Error = Error;
 
 	fn try_from(key: &PrivateKeyDer) -> Result<KeyPair, Error> {
-		#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
+		#[cfg(all(feature = "ring", not(feature = "_aws_lc_like")))]
 		let (kind, alg) = {
 			let PrivateKeyDer::Pkcs8(pkcs8) = key else {
 				return Err(Error::CouldNotParseKeyPair);
@@ -562,7 +562,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for KeyPair {
 
 			(kind, alg)
 		};
-		#[cfg(feature = "aws_lc_rs")]
+		#[cfg(feature = "_aws_lc_like")]
 		let (kind, alg) = {
 			let is_pkcs8 = matches!(key, PrivateKeyDer::Pkcs8(_));
 
@@ -622,7 +622,7 @@ impl From<KeyPair> for PrivateKeyDer<'static> {
 }
 
 /// The key size used for RSA key generation
-#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+#[cfg(all(feature = "crypto", feature = "_aws_lc_like"))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum RsaKeySize {
@@ -797,9 +797,9 @@ mod test {
 			&PKCS_ED25519,
 			&PKCS_ECDSA_P256_SHA256,
 			&PKCS_ECDSA_P384_SHA384,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			&PKCS_ECDSA_P521_SHA512,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			&PKCS_RSA_SHA256,
 		] {
 			let kp = KeyPair::generate_for(alg).expect("keygen");

--- a/rcgen/src/lib.rs
+++ b/rcgen/src/lib.rs
@@ -53,7 +53,7 @@ pub use csr::{CertificateSigningRequest, CertificateSigningRequestParams, Public
 pub use error::{Error, InvalidAsn1String};
 #[cfg(feature = "crypto")]
 pub use key_pair::KeyPair;
-#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+#[cfg(all(feature = "crypto", feature = "_aws_lc_like"))]
 pub use key_pair::RsaKeySize;
 pub use key_pair::{PublicKeyData, SigningKey, SubjectPublicKeyInfo};
 #[cfg(feature = "pem")]

--- a/rcgen/src/oid.rs
+++ b/rcgen/src/oid.rs
@@ -22,7 +22,7 @@ pub(crate) const EC_SECP_256_R1: &[u64] = &[1, 2, 840, 10045, 3, 1, 7];
 pub(crate) const EC_SECP_384_R1: &[u64] = &[1, 3, 132, 0, 34];
 /// secp521r1 in [RFC 5480](https://datatracker.ietf.org/doc/html/rfc5480#appendix-A)
 /// Currently this is only supported with the `aws_lc_rs` feature
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(feature = "_aws_lc_like")]
 pub(crate) const EC_SECP_521_R1: &[u64] = &[1, 3, 132, 0, 35];
 
 #[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]

--- a/rcgen/src/ring_like.rs
+++ b/rcgen/src/ring_like.rs
@@ -1,6 +1,6 @@
-#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+#[cfg(all(feature = "crypto", feature = "_aws_lc_like"))]
 pub(crate) use aws_lc_rs::*;
-#[cfg(all(feature = "crypto", feature = "ring", not(feature = "aws_lc_rs")))]
+#[cfg(all(feature = "crypto", feature = "ring", not(feature = "_aws_lc_like")))]
 pub(crate) use ring::*;
 
 #[cfg(feature = "crypto")]
@@ -14,18 +14,18 @@ pub(crate) fn ecdsa_from_pkcs8(
 	pkcs8: &[u8],
 	_rng: &dyn rand::SecureRandom,
 ) -> Result<signature::EcdsaKeyPair, Error> {
-	#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
+	#[cfg(all(feature = "ring", not(feature = "_aws_lc_like")))]
 	{
 		signature::EcdsaKeyPair::from_pkcs8(alg, pkcs8, _rng)._err()
 	}
 
-	#[cfg(feature = "aws_lc_rs")]
+	#[cfg(feature = "_aws_lc_like")]
 	{
 		signature::EcdsaKeyPair::from_pkcs8(alg, pkcs8)._err()
 	}
 }
 
-#[cfg(all(feature = "crypto", feature = "aws_lc_rs"))]
+#[cfg(all(feature = "crypto", feature = "_aws_lc_like"))]
 pub(crate) fn ecdsa_from_private_key_der(
 	alg: &'static signature::EcdsaSigningAlgorithm,
 	key: &[u8],
@@ -35,16 +35,16 @@ pub(crate) fn ecdsa_from_private_key_der(
 
 #[cfg(feature = "crypto")]
 pub(crate) fn rsa_key_pair_public_modulus_len(kp: &signature::RsaKeyPair) -> usize {
-	#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
+	#[cfg(all(feature = "ring", not(feature = "_aws_lc_like")))]
 	{
 		kp.public().modulus_len()
 	}
 
-	#[cfg(feature = "aws_lc_rs")]
+	#[cfg(feature = "_aws_lc_like")]
 	{
 		kp.public_modulus_len()
 	}
 }
 
-#[cfg(all(feature = "crypto", not(any(feature = "ring", feature = "aws_lc_rs"))))]
+#[cfg(all(feature = "crypto", not(any(feature = "ring", feature = "_aws_lc_like"))))]
 compile_error!("At least one of the 'ring' or 'aws_lc_rs' features must be activated when the 'crypto' feature is enabled");

--- a/rcgen/src/ring_like.rs
+++ b/rcgen/src/ring_like.rs
@@ -46,5 +46,8 @@ pub(crate) fn rsa_key_pair_public_modulus_len(kp: &signature::RsaKeyPair) -> usi
 	}
 }
 
-#[cfg(all(feature = "crypto", not(any(feature = "ring", feature = "_aws_lc_like"))))]
+#[cfg(all(
+	feature = "crypto",
+	not(any(feature = "ring", feature = "_aws_lc_like"))
+))]
 compile_error!("At least one of the 'ring' or 'aws_lc_rs' features must be activated when the 'crypto' feature is enabled");

--- a/rcgen/src/sign_algo.rs
+++ b/rcgen/src/sign_algo.rs
@@ -63,15 +63,15 @@ impl fmt::Debug for SignatureAlgorithm {
 		} else if self == &PKCS_ED25519 {
 			write!(f, "PKCS_ED25519")
 		} else {
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			if self == &PKCS_ECDSA_P521_SHA256 {
 				return write!(f, "PKCS_ECDSA_P521_SHA256");
 			}
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			if self == &PKCS_ECDSA_P521_SHA384 {
 				return write!(f, "PKCS_ECDSA_P521_SHA384");
 			}
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			if self == &PKCS_ECDSA_P521_SHA512 {
 				return write!(f, "PKCS_ECDSA_P521_SHA512");
 			}
@@ -106,11 +106,11 @@ impl SignatureAlgorithm {
 			//&PKCS_RSA_PSS_SHA256,
 			&PKCS_ECDSA_P256_SHA256,
 			&PKCS_ECDSA_P384_SHA384,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			&PKCS_ECDSA_P521_SHA256,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			&PKCS_ECDSA_P521_SHA384,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			&PKCS_ECDSA_P521_SHA512,
 			&PKCS_ED25519,
 		];
@@ -209,7 +209,7 @@ pub(crate) mod algo {
 	/// Note that this algorithm is not widely supported, and is not supported in TLS 1.3.
 	///
 	/// Only supported with the `aws_lc_rs` backend.
-	#[cfg(feature = "aws_lc_rs")]
+	#[cfg(feature = "_aws_lc_like")]
 	pub static PKCS_ECDSA_P521_SHA256: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]
@@ -224,7 +224,7 @@ pub(crate) mod algo {
 	/// Note that this algorithm is not widely supported, and is not supported in TLS 1.3.
 	///
 	/// Only supported with the `aws_lc_rs` backend.
-	#[cfg(feature = "aws_lc_rs")]
+	#[cfg(feature = "_aws_lc_like")]
 	pub static PKCS_ECDSA_P521_SHA384: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]
@@ -237,7 +237,7 @@ pub(crate) mod algo {
 	/// ECDSA signing using the P-521 curves and SHA-512 hashing as per [RFC 5758](https://tools.ietf.org/html/rfc5758#section-3.2)
 	///
 	/// Only supported with the `aws_lc_rs` backend.
-	#[cfg(feature = "aws_lc_rs")]
+	#[cfg(feature = "_aws_lc_like")]
 	pub static PKCS_ECDSA_P521_SHA512: SignatureAlgorithm = SignatureAlgorithm {
 		oids_sign_alg: &[EC_PUBLIC_KEY, EC_SECP_521_R1],
 		#[cfg(feature = "crypto")]

--- a/rustls-cert-gen/Cargo.toml
+++ b/rustls-cert-gen/Cargo.toml
@@ -12,10 +12,13 @@ keywords.workspace = true
 
 [features]
 default = ["ring"]
-aws_lc_rs = ["dep:aws-lc-rs", "rcgen/aws_lc_rs", "aws-lc-rs/aws-lc-sys"]
+aws_lc_rs = ["_aws_lc_like", "rcgen/aws_lc_rs", "aws-lc-rs/aws-lc-sys"]
 aws_lc_rs_unstable = ["rcgen/aws_lc_rs_unstable"]
-fips = ["dep:aws-lc-rs", "rcgen/aws_lc_rs", "aws-lc-rs/fips"]
+fips = ["_aws_lc_like", "rcgen/fips", "aws-lc-rs/fips"]
 ring = ["dep:ring", "rcgen/ring"]
+# Internal feature: enabled automatically whenever `aws_lc_rs` or `fips` is on.
+# Do not enable directly; use `aws_lc_rs` or `fips` instead.
+_aws_lc_like = ["dep:aws-lc-rs"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -195,7 +195,7 @@ pub enum KeyPairAlgorithm {
 	#[default]
 	EcdsaP256,
 	EcdsaP384,
-	#[cfg(feature = "aws_lc_rs")]
+	#[cfg(feature = "_aws_lc_like")]
 	EcdsaP521,
 	#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 	MlDsa44,
@@ -212,7 +212,7 @@ impl From<KeyPairAlgorithm> for &'static SignatureAlgorithm {
 			KeyPairAlgorithm::Ed25519 => &rcgen::PKCS_ED25519,
 			KeyPairAlgorithm::EcdsaP256 => &rcgen::PKCS_ECDSA_P256_SHA256,
 			KeyPairAlgorithm::EcdsaP384 => &rcgen::PKCS_ECDSA_P384_SHA384,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			KeyPairAlgorithm::EcdsaP521 => &rcgen::PKCS_ECDSA_P521_SHA512,
 			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 			KeyPairAlgorithm::MlDsa44 => &rcgen::PKCS_ML_DSA_44,
@@ -231,7 +231,7 @@ impl fmt::Display for KeyPairAlgorithm {
 			KeyPairAlgorithm::Ed25519 => write!(f, "ed25519"),
 			KeyPairAlgorithm::EcdsaP256 => write!(f, "ecdsa-p256"),
 			KeyPairAlgorithm::EcdsaP384 => write!(f, "ecdsa-p384"),
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			KeyPairAlgorithm::EcdsaP521 => write!(f, "ecdsa-p521"),
 			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 			KeyPairAlgorithm::MlDsa44 => write!(f, "ml-dsa-44"),
@@ -252,7 +252,7 @@ impl FromStr for KeyPairAlgorithm {
 			"ed25519" => Ok(Self::Ed25519),
 			"ecdsa-p256" => Ok(Self::EcdsaP256),
 			"ecdsa-p384" => Ok(Self::EcdsaP384),
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			"ecdsa-p521" => Ok(Self::EcdsaP521),
 			#[cfg(all(feature = "aws_lc_rs_unstable", not(feature = "fips")))]
 			"ml-dsa-44" => Ok(Self::MlDsa44),
@@ -367,7 +367,7 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg(feature = "aws_lc_rs")]
+	#[cfg(feature = "_aws_lc_like")]
 	fn serialize_end_entity_ecdsa_p521_sha512_sig() -> anyhow::Result<()> {
 		let ca = CertificateBuilder::new().certificate_authority().build()?;
 		let end_entity = CertificateBuilder::new()
@@ -488,7 +488,7 @@ mod tests {
 			"PKCS_ECDSA_P384_SHA384"
 		);
 
-		#[cfg(feature = "aws_lc_rs")]
+		#[cfg(feature = "_aws_lc_like")]
 		{
 			let keypair = KeyPair::generate_for(KeyPairAlgorithm::EcdsaP521.into())?;
 			assert_eq!(

--- a/verify-tests/Cargo.toml
+++ b/verify-tests/Cargo.toml
@@ -6,12 +6,15 @@ publish = false
 
 [features]
 default = []
-aws_lc_rs = ["rcgen/aws_lc_rs"]
+aws_lc_rs = ["_aws_lc_like", "rcgen/aws_lc_rs"]
 aws_lc_rs_unstable = ["dep:aws-lc-rs", "rcgen/aws_lc_rs_unstable", "rustls-webpki/aws-lc-rs-unstable"]
-fips = ["rcgen/fips"]
+fips = ["_aws_lc_like", "rcgen/fips"]
 pem = ["dep:pem", "rcgen/pem"]
 ring = ["rcgen/ring"]
 x509-parser = ["dep:x509-parser", "rcgen/x509-parser"]
+# Internal feature: enabled automatically whenever `aws_lc_rs` or `fips` is on.
+# Do not enable directly; use `aws_lc_rs` or `fips` instead.
+_aws_lc_like = []
 
 [dependencies]
 aws-lc-rs = { workspace = true, optional = true }

--- a/verify-tests/tests/botan.rs
+++ b/verify-tests/tests/botan.rs
@@ -75,7 +75,7 @@ fn test_botan_384() {
 }
 
 #[test]
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(feature = "_aws_lc_like")]
 fn test_botan_521() {
 	let (params, _) = default_params();
 	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P521_SHA512).unwrap();

--- a/verify-tests/tests/generic.rs
+++ b/verify-tests/tests/generic.rs
@@ -15,11 +15,11 @@ mod test_key_params_mismatch {
 			&rcgen::PKCS_RSA_SHA256,
 			&rcgen::PKCS_ECDSA_P256_SHA256,
 			&rcgen::PKCS_ECDSA_P384_SHA384,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			&rcgen::PKCS_ECDSA_P521_SHA256,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			&rcgen::PKCS_ECDSA_P521_SHA384,
-			#[cfg(feature = "aws_lc_rs")]
+			#[cfg(feature = "_aws_lc_like")]
 			&rcgen::PKCS_ECDSA_P521_SHA512,
 			&rcgen::PKCS_ED25519,
 		];

--- a/verify-tests/tests/openssl.rs
+++ b/verify-tests/tests/openssl.rs
@@ -210,7 +210,7 @@ fn test_openssl_384() {
 }
 
 #[test]
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(feature = "_aws_lc_like")]
 fn test_openssl_521() {
 	let (params, _) = util::default_params();
 	let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P521_SHA512).unwrap();
@@ -533,7 +533,7 @@ fn test_openssl_crl_dps_parse() {
 }
 
 #[test]
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(feature = "_aws_lc_like")]
 fn test_openssl_pkcs1_and_sec1_keys() {
 	use openssl::ec::{EcGroup, EcKey};
 	use openssl::nid::Nid;


### PR DESCRIPTION
At present, this crate nicely supports the FIPS mode of aws-lc-rs. However, one is presented with a catch-22; if one depends on _only_ the fips feature of this crate, the crate will fail to compile as critical codepaths have been commented out (the aws-lc-rs feature flag not being on).

so

```
rcgen = { version = "0.whatever", features = ["fips"] # fails to compile
rcgen = { version = "0.whatever", features = ["aws-lc-rs", "fips"] # links against non-FIPS crypto.
```

Meanwhile, if one depends on the aws-lc-rs feature, it also enables the non-fips backend of aws-lc-rs, meaning that one can't use cargo deny as easily to block non-FIPS crypto backends.

I wasn't sure how to avoid this. One approach would simply be to depend on aws-lc-rs with default features on. Another would be to have the feature gates dotted around the codebase be on any(aws_lc_rs, fips) rather than just aws_lc_rs.

I figured a nice approach might be to have either feature trigger an 'aws-lc-like' feature which is what can be used through the codebase, as this minimises the likelihood that future dev work will re-introduce the dependency.

However, this does introduce a public-facing internal feature flag.

Looking forward to a review; happy to make changes as necessary! Just trying to be an OSS good citizen!