### PR TITLE
fix: Workaround E0119 trait conflict introduced by time v0.3.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pem = "3.0.2"
 pki-types = { package = "rustls-pki-types", version = "1.4.1" }
 ring = "0.17"
 rustls-webpki = { version = "0.103", features = ["ring", "std"] }
-time = { version = "0.3.6", default-features = false }
+time = { version = ">=0.3.6, <0.3.48", default-features = false }
 x509-parser = "0.18"
 yasna = { version = "0.6", features = ["time", "std"] }
 zeroize = { version = "1.2" }


### PR DESCRIPTION
Constrains the `time` dependency in `Cargo.toml` to fix a broken build caused by the recent `time` `v0.3.48` release. 

time `0.3.48` introduces an upstream trait implementation that conflicts with `rcgen`'s generic `impl<T: Into<String>> From<T>` bounds for `OtherNameValue` and `DnValue`. Without this constraint, running `cargo update && cargo build` fails with an `E0119: conflicting implementations` error.

Updating Cargo.toml to reject time 0.3.48 fixes `cargo update` for rcgen and downstream users until the incompatibility can be resolved.

<details>
<summary><b>rustc error context</b></summary>

```rust
error[E0119]: conflicting implementations of trait `From<format_description::parse::format_item::HourBase>` for type `<format_description::parse::format_item::HourBase as format_description::parse::format_item::ModifierValue>::Type`
   --> rcgen/src/lib.rs:359:1
    |
359 | / impl<T> From<T> for OtherNameValue
360 | | where
361 | |     T: Into<String>,
    | |____________________^
    |
    = note: conflicting implementation in crate `time`:
            - impl From<format_description::parse::format_item::HourBase> for <format_description::parse::format_item::HourBase as format_description::parse::format_item::ModifierValue>::Type;
    = note: upstream crates may add a new impl of trait `std::convert::Into<std::string::String>` for type `time::format_description::parse::format_item::HourBase` in future versions

error[E0119]: conflicting implementations of trait `From<format_description::parse::format_item::HourBase>` for type `<format_description::parse::format_item::HourBase as format_description::parse::format_item::ModifierValue>::Type`
   --> rcgen/src/lib.rs:452:1
    |
452 | / impl<T> From<T> for DnValue
453 | | where
454 | |     T: Into<String>,
    | |____________________^
    |
    = note: conflicting implementation in crate `time`:
            - impl From<format_description::parse::format_item::HourBase> for <format_description::parse::format_item::HourBase as format_description::parse::format_item::ModifierValue>::Type;
    = note: upstream crates may add a new impl of trait `std::convert::Into<std::string::String>` for type `time::format_description::parse::format_item::HourBase` in future versions

For more information about this error, try `rustc --explain E0119`.
error: could not compile `rcgen` (lib) due to 2 previous errors