### PR TITLE
rustls-cert-gen: fix useless_borrows_in_formatting findings

### DIFF
--- a/rustls-cert-gen/src/cert.rs
+++ b/rustls-cert-gen/src/cert.rs
@@ -279,11 +279,11 @@ impl PemCertifiedKey {
 
 		let key_path = dir.join(format!("{name}.key.pem"));
 		let mut key_out = File::create(key_path)?;
-		write!(key_out, "{}", &self.private_key_pem)?;
+		write!(key_out, "{}", self.private_key_pem)?;
 
 		let cert_path = dir.join(format!("{name}.pem"));
 		let mut cert_out = File::create(cert_path)?;
-		write!(cert_out, "{}", &self.cert_pem)?;
+		write!(cert_out, "{}", self.cert_pem)?;
 
 		Ok(())
 	}


### PR DESCRIPTION
Of the form:

```
error: redundant reference in `write!` argument
   --> rustls-cert-gen/src/cert.rs:282:25
    |
282 |         write!(key_out, "{}", &self.private_key_pem)?;
    |                               ^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `self.private_key_pem`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
    = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`
```