### PR TITLE
Omit default cA flag value as required by spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rcgen"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "aws-lc-rs",
  "openssl",

--- a/rcgen/Cargo.toml
+++ b/rcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcgen"
-version = "0.14.8"
+version = "0.14.9"
 documentation = "https://docs.rs/rcgen"
 description.workspace = true
 repository.workspace = true

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -195,15 +195,10 @@ impl CertificateParams {
 			));
 			writer.next().write_set(|writer| {
 				writer.next().write_sequence(|writer| {
-					// Write key_usage
 					self.write_key_usage(writer.next());
-					// Write subject_alt_names
 					self.write_subject_alt_names(writer.next());
 					self.write_extended_key_usage(writer.next());
-					// Write is_ca
-					self.write_is_ca(writer.next());
-
-					// Write custom extensions
+					self.write_ca_extensions(writer, None);
 					for ext in &self.custom_extensions {
 						write_x509_extension(writer.next(), &ext.oid, ext.critical, |writer| {
 							writer.write_der(ext.content())
@@ -254,15 +249,26 @@ impl CertificateParams {
 	}
 
 	/// Write a certificate's BasicConstraints as defined in RFC 5280.
-	fn write_is_ca(&self, writer: DERWriter) {
+	fn write_ca_extensions(&self, writer: &mut DERWriterSeq, pub_key_spki: Option<&[u8]>) {
 		let is_ca = match &self.is_ca {
 			IsCa::Ca(bc) => Some(bc),
 			IsCa::ExplicitNoCa => None,
 			IsCa::NoCa => return,
 		};
 
+		if let Some(pub_key_spki) = pub_key_spki {
+			write_x509_extension(
+				writer.next(),
+				oid::SUBJECT_KEY_IDENTIFIER,
+				false,
+				|writer| {
+					writer.write_bytes(&self.key_identifier_method.derive(pub_key_spki));
+				},
+			);
+		}
+
 		// Write basic_constraints
-		write_x509_extension(writer, oid::BASIC_CONSTRAINTS, true, |writer| {
+		write_x509_extension(writer.next(), oid::BASIC_CONSTRAINTS, true, |writer| {
 			writer.write_sequence(|writer| {
 				writer.next().write_bool(is_ca.is_some()); // cA flag
 				if let Some(BasicConstraints::Constrained(path_len_constraint)) = is_ca {
@@ -550,48 +556,8 @@ impl CertificateParams {
 			);
 		}
 
-		match self.is_ca {
-			IsCa::Ca(ref constraint) => {
-				// Write subject_key_identifier
-				write_x509_extension(
-					writer.next(),
-					oid::SUBJECT_KEY_IDENTIFIER,
-					false,
-					|writer| {
-						writer.write_bytes(&self.key_identifier_method.derive(pub_key_spki));
-					},
-				);
-				// Write basic_constraints
-				write_x509_extension(writer.next(), oid::BASIC_CONSTRAINTS, true, |writer| {
-					writer.write_sequence(|writer| {
-						writer.next().write_bool(true); // cA flag
-						if let BasicConstraints::Constrained(path_len_constraint) = constraint {
-							writer.next().write_u8(*path_len_constraint);
-						}
-					});
-				});
-			},
-			IsCa::ExplicitNoCa => {
-				// Write subject_key_identifier
-				write_x509_extension(
-					writer.next(),
-					oid::SUBJECT_KEY_IDENTIFIER,
-					false,
-					|writer| {
-						writer.write_bytes(&self.key_identifier_method.derive(pub_key_spki));
-					},
-				);
-				// Write basic_constraints
-				write_x509_extension(writer.next(), oid::BASIC_CONSTRAINTS, true, |writer| {
-					writer.write_sequence(|writer| {
-						writer.next().write_bool(false); // cA flag
-					});
-				});
-			},
-			IsCa::NoCa => {},
-		}
+		self.write_ca_extensions(writer, Some(pub_key_spki));
 
-		// Write the custom extensions
 		for ext in &self.custom_extensions {
 			write_x509_extension(writer.next(), &ext.oid, ext.critical, |writer| {
 				writer.write_der(ext.content())

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -507,23 +507,9 @@ impl CertificateParams {
 			);
 		}
 
-		// Write subject_alt_names
 		self.write_subject_alt_names(writer.next());
-
-		// Write standard key usage
 		self.write_key_usage(writer.next());
-
-		// Write extended key usage
-		if !self.extended_key_usages.is_empty() {
-			write_x509_extension(writer.next(), oid::EXT_KEY_USAGE, false, |writer| {
-				writer.write_sequence(|writer| {
-					for usage in self.extended_key_usages.iter() {
-						let oid = ObjectIdentifier::from_slice(usage.oid());
-						writer.next().write_oid(&oid);
-					}
-				});
-			});
-		}
+		self.write_extended_key_usage(writer.next());
 
 		if let Some(name_constraints) = &self.name_constraints {
 			// If both trees are empty, the extension must be omitted.

--- a/rcgen/src/certificate.rs
+++ b/rcgen/src/certificate.rs
@@ -270,9 +270,16 @@ impl CertificateParams {
 		// Write basic_constraints
 		write_x509_extension(writer.next(), oid::BASIC_CONSTRAINTS, true, |writer| {
 			writer.write_sequence(|writer| {
-				writer.next().write_bool(is_ca.is_some()); // cA flag
-				if let Some(BasicConstraints::Constrained(path_len_constraint)) = is_ca {
-					writer.next().write_u8(*path_len_constraint); // pathLenConstraint integer
+				let Some(constraints) = is_ca else {
+					return;
+				};
+
+				writer.next().write_bool(true); // cA flag
+				match constraints {
+					BasicConstraints::Unconstrained => {},
+					BasicConstraints::Constrained(path_len_constraint) => {
+						writer.next().write_u8(*path_len_constraint); // pathLenConstraint integer
+					},
 				}
 			});
 		});
@@ -1094,6 +1101,8 @@ mod tests {
 
 	#[cfg(feature = "x509-parser")]
 	use pki_types::pem::PemObject;
+	#[cfg(feature = "crypto")]
+	use x509_parser::oid_registry::OID_X509_EXT_BASIC_CONSTRAINTS;
 
 	#[cfg(feature = "pem")]
 	use super::*;
@@ -1139,6 +1148,40 @@ mod tests {
 					ext.parsed_extension()
 				{
 					assert!(usage.flags == 7);
+					found = true;
+				}
+			}
+		}
+
+		assert!(found);
+	}
+
+	#[cfg(feature = "crypto")]
+	#[test]
+	fn test_explicit_no_ca() {
+		let params = CertificateParams {
+			is_ca: IsCa::ExplicitNoCa,
+			..CertificateParams::default()
+		};
+
+		// Make the cert
+		let key_pair = KeyPair::generate().unwrap();
+		let cert = params.self_signed(&key_pair).unwrap();
+
+		// Parse it
+		let (_rem, cert) = x509_parser::parse_x509_certificate(cert.der()).unwrap();
+
+		// Check the basic constraints extension
+		let mut found = false;
+		for ext in cert.extensions() {
+			if ext.oid == OID_X509_EXT_BASIC_CONSTRAINTS {
+				// The cA flag is DEFAULT FALSE, so DER requires it to be omitted:
+				// the extension value must be an empty SEQUENCE
+				assert_eq!(ext.value, vec![0x30, 0x00]);
+				if let x509_parser::extensions::ParsedExtension::BasicConstraints(bc) =
+					ext.parsed_extension()
+				{
+					assert!(!bc.ca);
 					found = true;
 				}
 			}


### PR DESCRIPTION
## Proposed release notes

Previous versions generated DER that is strictly incompatible with the spec, writing an explicit `false` value for `IsCa::ExplicitNoCa` where this should be omitted (as it's the default).

Fixes #443.