### PR TITLE
lint: use as_chunks instead of chunks_exact

### DIFF
--- a/rcgen/src/string.rs
+++ b/rcgen/src/string.rs
@@ -427,7 +427,9 @@ impl BmpString {
 
 		// FIXME: Update this when `array_chunks` is stabilized.
 		for maybe_char in char::decode_utf16(
-			vec.chunks_exact(2)
+			vec.as_chunks::<2>()
+				.0
+				.iter()
 				.map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]])),
 		) {
 			// We check we only use the BMP subset of Unicode (the first 65 536 code points)
@@ -546,7 +548,9 @@ impl UniversalString {
 
 		// FIXME: Update this when `array_chunks` is stabilized.
 		for maybe_char in vec
-			.chunks_exact(4)
+			.as_chunks::<4>()
+			.0
+			.iter()
 			.map(|chunk| u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
 		{
 			if core::char::from_u32(maybe_char).is_none() {


### PR DESCRIPTION
From a rust-clippy 1.98 CI run:
```
error: using `chunks_exact` with a constant chunk size
   --> rcgen/src/string.rs:430:8
    |
430 |             vec.chunks_exact(2)
    |                 ^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<2>().0.iter()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks
    = note: `-D clippy::chunks-exact-to-as-chunks` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::chunks_exact_to_as_chunks)]`

error: using `chunks_exact` with a constant chunk size
   --> rcgen/src/string.rs:549:5
    |
549 |             .chunks_exact(4)
    |              ^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<4>().0.iter()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks

    Checking regex-syntax v0.8.10
error: could not compile `rcgen` (lib) due to 2 previous errors
```
`as_chunks` stablized in rust 1.88.0, which is this crate's MSRV.